### PR TITLE
established config for binary masks

### DIFF
--- a/solaris/data/config_skeleton.yml
+++ b/solaris/data/config_skeleton.yml
@@ -26,6 +26,7 @@ data_specs:
                          # 'zscore', '8bit', '16bit'
   channels:  # number of channels in the input imagery.
   label_type: mask  # one of ['mask', 'bbox']
+  is_categorical: false  # are the labels binary (default) or categorical?
   mask_channels: 1  # number of channels in the training mask
   val_holdout_frac:  # if empty, assumes that separate data ref files define the
                      # training and validation dataset. If a float between 0 and

--- a/solaris/nets/datagen.py
+++ b/solaris/nets/datagen.py
@@ -132,6 +132,8 @@ class KerasSegmentationSequence(keras.utils.Sequence):
             im = imread(self.df['image'].iloc[image_idxs[i]])
             if self.config['data_specs']['label_type'] == 'mask':
                 label = imread(self.df['label'].iloc[image_idxs[i]])
+                if not self.config['data_specs']['is_categorical']:
+                    label[label != 0] = 1
                 aug_result = self.aug(image=im, mask=label)
                 # if image shape is 2D, convert to 3D
                 scaled_im = scale_for_model(
@@ -195,6 +197,8 @@ class TorchDataset(Dataset):
         # Generate indexes of the batch
         image = imread(self.df['image'].iloc[idx])
         mask = imread(self.df['label'].iloc[idx])
+        if not self.config['data_specs']['is_categorical']:
+            mask[mask != 0] = 1
         sample = {'image': image, 'label': mask}
         if self.aug:
             sample = self.aug(**sample)

--- a/tests/test_nets/test_datagen.py
+++ b/tests/test_nets/test_datagen.py
@@ -22,7 +22,8 @@ class TestDataGenerator(object):
                    'width': 30,
                    'channels': 1,
                    'label_type': 'mask',
-                   'mask_channels': 1
+                   'mask_channels': 1,
+                   'is_categorical': False
                    },
                   'batch_size': 1,
                   'training_augmentation':
@@ -39,6 +40,7 @@ class TestDataGenerator(object):
         expected_mask = skimage.io.imread(os.path.join(data_dir,
                                                        'datagen_sample',
                                                        'sample_mask_1.tif'))
+        expected_mask[expected_mask != 0] = 1  # this should be binary
 
         assert np.array_equal(im, expected_im[np.newaxis, :, :, np.newaxis])
         assert np.array_equal(mask,
@@ -57,7 +59,8 @@ class TestDataGenerator(object):
                    'width': 30,
                    'channels': 1,
                    'label_type': 'mask',
-                   'mask_channels': 1
+                   'mask_channels': 1,
+                   'is_categorical': False
                    },
                   'batch_size': 1,
                   'training_augmentation':
@@ -75,6 +78,7 @@ class TestDataGenerator(object):
         expected_mask = skimage.io.imread(os.path.join(data_dir,
                                                        'datagen_sample',
                                                        'sample_mask_1.tif'))
+        expected_mask[expected_mask != 0] = 1  # this should be binary
 
         assert np.array_equal(sample['image'],
                               expected_im[np.newaxis, :, :, np.newaxis])


### PR DESCRIPTION
Resolves #81. Adds an additional flag to the config file: `config['data_specs']['is_categorical']`: by default this is `False`. When `False`, mask values will be rescaled such that any value that's not a 1 is a 0; if `True`, no rescaling of mask values occurs.