### PR TITLE
Iss114 tileutils

### DIFF
--- a/solaris/tile/__init__.py
+++ b/solaris/tile/__init__.py
@@ -1,1 +1,1 @@
-from . import main, vector_utils
+from . import raster_tile, vector_tile

--- a/solaris/tile/vector_tile.py
+++ b/solaris/tile/vector_tile.py
@@ -1,50 +1,5 @@
 from shapely.geometry import box
 import geopandas as gpd
-from rasterio import features
-from rasterio import Affine
-import numpy as np
-
-
-def read_vector_file(geoFileName):
-    """Read Fiona-Supported Files into GeoPandas GeoDataFrame.
-
-    Warning
-    ----
-    This will raise an exception for empty GeoJSON files, which GDAL and Fiona
-    cannot read. ``try/except`` the :py:exc:`Fiona.errors.DriverError` or
-    :py:exc:`Fiona._err.CPLE_OpenFailedError` if you must use this.
-
-    """
-
-    return gpd.read_file(geoFileName)
-
-
-def transformToUTM(gdf, utm_crs, estimate=True, calculate_sindex=True):
-    """Transform GeoDataFrame to UTM coordinate reference system.
-
-    Arguments
-    ---------
-    gdf : :py:class:`geopandas.GeoDataFrame`
-        :py:class:`geopandas.GeoDataFrame` to transform.
-    utm_crs : str
-        :py:class:`rasterio.crs.CRS` string for destination UTM CRS.
-    estimate : bool, optional
-        .. deprecated:: 0.2.0
-            This argument is no longer used.
-    calculate_sindex : bool, optional
-        .. deprecated:: 0.2.0
-            This argument is no longer used.
-
-    Returns
-    -------
-    gdf : :py:class:`geopandas.GeoDataFrame`
-        The input :py:class:`geopandas.GeoDataFrame` converted to
-        `utm_crs` coordinate reference system.
-
-    """
-
-    gdf = gdf.to_crs(utm_crs)
-    return gdf
 
 
 def search_gdf_bounds(gdf, tile_bounds):
@@ -103,7 +58,7 @@ def search_gdf_polygon(gdf, tile_polygon):
 
 def vector_tile_utm(gdf, tile_bounds, min_partial_perc=0.1,
                     geom_type="Polygon", use_sindex=True):
-    """Wrapper for :func:`clip_gdf` that converts `tile_bounds` to a polygon.
+    """Wrapper for :func:`clip_gdf` that clips `tile_bounds` to a polygon.
 
     Arguments
     ---------
@@ -135,34 +90,25 @@ def vector_tile_utm(gdf, tile_bounds, min_partial_perc=0.1,
     return small_gdf
 
 
-def getCenterOfGeoFile(gdf, estimate=True):
-
-    #TODO implement calculate UTM from gdf  see osmnx implementation
-
-    pass
-
-
 def clip_gdf(gdf, poly_to_cut, min_partial_perc=0.0, geom_type="Polygon",
              use_sindex=True):
     """Clip GDF to a provided polygon.
 
-    Note
-    ----
     Clips objects within `gdf` to the region defined by
-    `poly_to_cut`. Also adds several columns to the output:
+    `poly_to_cut`. Also adds several columns to the output::
 
-    `origarea`
-        The original area of the polygons (only used if `geom_type` ==
-        ``"Polygon"``).
-    `origlen`
-        The original length of the objects (only used if `geom_type` ==
-        ``"LineString"``).
-    `partialDec`
-        The fraction of the object that remains after clipping
-        (fraction of area for Polygons, fraction of length for
-        LineStrings.) Can filter based on this by using `min_partial_perc`.
-    `truncated`
-        Boolean indicator of whether or not an object was clipped.
+        `origarea`
+            The original area of the polygons (only used if `geom_type` ==
+            ``"Polygon"``).
+        `origlen`
+            The original length of the objects (only used if `geom_type` ==
+            ``"LineString"``).
+        `partialDec`
+            The fraction of the object that remains after clipping
+            (fraction of area for Polygons, fraction of length for
+            LineStrings.) Can filter based on this by using `min_partial_perc`.
+        `truncated`
+            Boolean indicator of whether or not an object was clipped.
 
     Arguments
     ---------

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -1,6 +1,6 @@
 from ..utils.core import _check_df_load, _check_rasterio_im_load
 from ..utils.core import _check_skimage_im_load
-from ..utils.tile import vector_gdf_get_projection_unit, calculate_UTM_crs
+from ..utils.geo import gdf_get_projection_unit, calculate_utm_crs
 from ..utils.geo import geometries_internal_intersection, _check_wkt_load
 import numpy as np
 from shapely.geometry import shape
@@ -530,11 +530,11 @@ def road_mask(df, out_file=None, reference_im=None, geom_col='geometry',
     df[geom_col] = df[geom_col].apply(_check_wkt_load)
 
     # Check if dataframe is in the appropriate units (meters, and reproject if not)
-    unit = vector_gdf_get_projection_unit(df)
+    unit = gdf_get_projection_unit(df)
     if unit != "meter":
         # Pick UTM zone
         coords = [df[geom_col].bounds['minx'].min(), df[geom_col].bounds['miny'].min(), df[geom_col].bounds['maxx'].max(), df[geom_col].bounds['maxy'].max()]
-        crs = calculate_UTM_crs(coords)
+        crs = calculate_utm_crs(coords)
         # REPROJECT
         orig_crs = df.crs
         df = df.to_crs(crs)

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -304,39 +304,47 @@ def get_overlapping_subset(gdf, im=None, bbox=None, bbox_crs=None):
     return gdf.iloc[intersectors, :]
 
 
-def gdf_to_yolo(geodataframe, image, output_dir, column='single_id', im_size=(0, 0), min_overlap=0.66, remove_no_labels=1):
-    """Convert a geodataframe containing polygons to yolo/yolt readable format (.txt files).
+def gdf_to_yolo(geodataframe, image, output_dir, column='single_id',
+                im_size=(0, 0), min_overlap=0.66, remove_no_labels=1):
+    """Convert a geodataframe containing polygons to yolo/yolt format.
+
     Arguments
     ---------
     geodataframe : str
-        Path to a :class:`geopandas.GeoDataFrame` with a
-        column named ``'geometry'``.  Can be created from a geojson with labels for unique objects.
-        Can be converted to this format with geodataframe=gpd.read_file("./xView_30.geojson")
+        Path to a :class:`geopandas.GeoDataFrame` with a column named
+        ``'geometry'``.  Can be created from a geojson with labels for unique
+        objects. Can be converted to this format with
+        ``geodataframe=gpd.read_file("./xView_30.geojson")``.
     im_path : str
-        Path to a georeferenced image (ie a GeoTIFF or png created with GDAL) that geolocates to the
-        same geography as the `geojson`(s). If a directory, the bounds of each
-        GeoTIFF will be loaded in and all overlapping geometries will be
-        transformed. This function will also accept a
-        :class:`osgeo.gdal.Dataset` or :class:`rasterio.DatasetReader` with
-        georeferencing information in this argument.
+        Path to a georeferenced image (ie a GeoTIFF or png created with GDAL)
+        that geolocates to the same geography as the `geojson`(s). If a
+        directory, the bounds of each GeoTIFF will be loaded in and all
+        overlapping geometries will be transformed. This function will also
+        accept a :class:`osgeo.gdal.Dataset` or :class:`rasterio.DatasetReader`
+        with georeferencing information in this argument.
     output_dir : str
-        Path to an output directory where all of the yolo readable text files will be placed.
-    column : str
-        The column name that contians an unique integer id for each of object class.
-    im_size : tuple
-        A tuple specifying the x and y heighth of a an image.  If specified as (0,0) this is automatically
-        extracted from the image.
-    min_overlap : float
-        A float value ranging from 0 to +1.  This is a percantge.  If a polygon does not overlap the image
-        by at least min_overlap, the polygon is discarded.  i.e. 0.66 = 66%, at least 66% of the polygon must
-        intersect with the image or else it is discarded. Default value of 0.66.
-    remove_no_labels : int
-        An int value of 0 or 1.  If 1, any image not containing any objects will be moved to a directory in the same root
-        path as your input image.  If 0, no images will be moved. Default value of 1.
+        Path to an output directory where all of the yolo readable text files
+        will be placed.
+    column : str, optional
+        The column name that contians an unique integer id for each of object
+        class.
+    im_size : tuple, optional
+        A tuple specifying the x and y heighth of a an image.  If specified as
+        ``(0,0)`` (the default,) then the size is determined automatically.
+    min_overlap : float, optional
+        A float value ranging from 0 to 1.  This is a percantage.  If a polygon
+        does not overlap the image by at least min_overlap, the polygon is
+        discarded.  i.e. 0.66 = 66%. Default value of 0.66.
+    remove_no_labels : int, optional
+        An int value of 0 or 1.  If 1, any image not containing any objects
+        will be moved to a directory in the same root path as your input image.
+        If 0, no images will be moved. Default value of 1.
+
     Returns
     -------
-    gdf : :class:`geopandas.GeoDataFrame`.  The txt file will be written to the output_dir, however the the output gdf itself
-    can be returned from this function if required.
+    gdf : :class:`geopandas.GeoDataFrame`.
+        The txt file will be written to the output_dir, however the the output
+        gdf itself is returned.
     """
     if im_size == (0, 0):
         imsize_extract = rasterio.open(image).read()

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,7 +5,7 @@ class TestImports(object):
         from solaris.utils import core, geo, config, tile, cli
         from solaris import data
         from solaris.vector import polygon, graph, mask
-        from solaris.tile import main, vector_tile
+        from solaris.tile import raster_tile, vector_tile
         from solaris.raster import image
         from solaris.nets import callbacks, datagen, infer, model_io, losses
         from solaris.nets import train, transform, zoo

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -5,7 +5,7 @@ class TestImports(object):
         from solaris.utils import core, geo, config, tile, cli
         from solaris import data
         from solaris.vector import polygon, graph, mask
-        from solaris.tile import main, vector_utils
+        from solaris.tile import main, vector_tile
         from solaris.raster import image
         from solaris.nets import callbacks, datagen, infer, model_io, losses
         from solaris.nets import train, transform, zoo


### PR DESCRIPTION
Re-organizing tiler utilities:

- Removing duplicated functionality
- Moving a lot of the code to `solaris.utils.geo` that isn't strictly for tiling
- re-naming tiler functionality (resolves #114 and resolves #115)