### PR TITLE
Iss135: standardize CRS passing

### DIFF
--- a/solaris/eval/base.py
+++ b/solaris/eval/base.py
@@ -1,5 +1,3 @@
-from __future__ import print_function, with_statement, division
-
 import shapely.wkt
 import geopandas as gpd
 import pandas as pd

--- a/solaris/utils/core.py
+++ b/solaris/utils/core.py
@@ -69,6 +69,20 @@ def _check_geom(geom):
         return Point(geom)
 
 
+def _check_crs(input_crs):
+    """Convert CRS to the integer format passed by ``solaris``."""
+    if isinstance(input_crs, dict):
+        # assume it's an {'init': 'epsgxxxx'} dict
+        out_crs = int(input_crs['init'].lower().strip('epsg:'))
+    elif isinstance(input_crs, str):
+        # handle PROJ4 strings, epsg strings, wkt strings
+        out_crs = rasterio.crs.CRS.from_string(input_crs).to_epsg()
+    elif isinstance(input_crs, rasterio.crs.CRS):
+        out_crs = input_crs.to_epsg()
+    elif isinstance(input_crs, int):
+        out_crs = input_crs
+    return out_crs
+
 def get_data_paths(path, infer=False):
     """Get a pandas dataframe of images and labels from a csv.
 

--- a/tests/test_eval/off_nadir_dataset_test.py
+++ b/tests/test_eval/off_nadir_dataset_test.py
@@ -1,6 +1,6 @@
 import os
-from solaris.eval.challenges import off_nadir_buildings
 import solaris
+from solaris.eval.challenges import off_nadir_buildings
 import subprocess
 import pandas as pd
 


### PR DESCRIPTION
Thank you for submitting your PR. Please read the template below, fill it out as appropriate, and make additional changes to your code as needed. Please feel free to submit your PR even if it doesn't satisfy all of the requirements below - simply prepend [WIP] to the PR title until it is ready for review by a maintainer. If you need assistance or review from a maintainer, add the label __Status: Help Needed__ or __Status: Review Needed__ respectively. After review, a maintainer will add the label __Status: Revision Needed__ if further work is required for the PR to be merged.

# Description

Standardizes how CRSs are passed around through `solaris`. Instead of the various different options (e.g. if it's WGS84 lat/long, is it `{'init': 'epsg:4326'}`, `EPSG4326`, `EPSG:4326`, `4326`, a proj4 string, or a `rasterio.crs.CRS` instance containing the same information?), `solaris` now only passes the integer EPSG code. `_check_crs()` was added to `solaris.utils.core` to convert any standard input to that format, and called in every function that takes a CRS as an argument.

Fixes #135

## Type of change

Please delete options that are not relevant.

Maintenance

# Checklist:

- [x] My PR has a descriptive title
- [x] My code follows PEP8
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
