### PR TITLE
ISS134: Standardized buffering for mask creation

### DIFF
--- a/solaris/bin/make_masks.py
+++ b/solaris/bin/make_masks.py
@@ -16,65 +16,69 @@ def main():
     parser.add_argument('--source_file', '-s', type=str,
                         help='Full path to file to create mask from.')
     parser.add_argument('--reference_image', '-r', type=str,
-                        help='Full path to a georegistered image in the same' +
-                        ' coordinate system (for conversion to pixels) or in' +
-                        ' the target coordinate system (for conversion to a' +
+                        help='Full path to a georegistered image in the same'
+                        ' coordinate system (for conversion to pixels) or in'
+                        ' the target coordinate system (for conversion to a'
                         ' geographic coordinate reference system).')
     parser.add_argument('--output_path', '-o', type=str,
-                        help='Full path to the output file for the converted' +
+                        help='Full path to the output file for the converted'
                         'footprints.')
     parser.add_argument('--geometry_column', '-g', type=str,
-                        default='geometry', help='The column containing' +
-                        ' footprint polygons to transform. If not provided,' +
+                        default='geometry', help='The column containing'
+                        ' footprint polygons to transform. If not provided,'
                         ' defaults to "geometry".')
     parser.add_argument('--transform', '-t', action='store_true',
-                        default=False, help='Use this flag if the geometries' +
-                        ' are in a georeferenced coordinate system and' +
+                        default=False, help='Use this flag if the geometries'
+                        ' are in a georeferenced coordinate system and'
                         ' need to be converted to pixel coordinates.')
     parser.add_argument('--value', '-v', type=int, default=255,
-                        help='The value to set for labeled pixels in the' +
+                        help='The value to set for labeled pixels in the'
                         ' mask. Defaults to 255.')
     parser.add_argument('--footprint', '-f', action='store_true',
-                        default=False, help='If this flag is set, the mask' +
-                        ' will include filled-in building footprints as a' +
+                        default=False, help='If this flag is set, the mask'
+                        ' will include filled-in building footprints as a'
                         ' channel.')
     parser.add_argument('--edge', '-e', action='store_true',
-                        default=False, help='If this flag is set, the mask' +
+                        default=False, help='If this flag is set, the mask'
                         ' will include the building edges as a channel.')
     parser.add_argument('--edge_width', '-ew', type=int, default=3,
-                        help='Pixel thickness of the edges in the edge mask.' +
+                        help='Pixel thickness of the edges in the edge mask.'
                         ' Defaults to 3 if not provided.')
     parser.add_argument('--edge_type', '-et', type=str, default='inner',
-                        help='Type of edge: either inner or outer. Defaults' +
+                        help='Type of edge: either inner or outer. Defaults'
                         ' to inner if not provided.')
     parser.add_argument('--contact', '-c', action='store_true',
-                        default=False, help='If this flag is set, the mask' +
-                        ' will include contact points between buildings as a' +
+                        default=False, help='If this flag is set, the mask'
+                        ' will include contact points between buildings as a'
                         ' channel.')
     parser.add_argument('--contact_spacing', '-cs', type=int, default=10,
-                        help='Sets the maximum distance between two' +
-                        ' buildings, in source file units, that will be' +
+                        help='Sets the maximum distance between two'
+                        ' buildings, in source file units, that will be'
                         ' identified as a contact. Defaults to 10.')
+    parser.add_argument('--metric_widths', '-m', action='store_true',
+                        default=False, help='Use this flag if any widths '
+                        '(--contact-spacing specifically) should be in metric '
+                        'units instead of pixel units.')
     parser.add_argument('--batch', '-b', action='store_true', default=False,
-                        help='Use this flag if you wish to operate on' +
-                        ' multiple files in batch. In this case,' +
-                        ' --argument-csv must be provided. See help' +
-                        ' for --argument_csv and the codebase docs at' +
+                        help='Use this flag if you wish to operate on'
+                        ' multiple files in batch. In this case,'
+                        ' --argument-csv must be provided. See help'
+                        ' for --argument_csv and the codebase docs at'
                         ' https://cw-geodata.readthedocs.io for more info.')
     parser.add_argument('--argument_csv', '-a', type=str,
-                        help='The reference file for variable values for' +
-                        ' batch processing. It must contain columns to pass' +
-                        ' the source_file and reference_image arguments, and' +
-                        ' can additionally contain columns providing the' +
-                        ' footprint_column and decimal_precision arguments' +
-                        ' if you wish to define them differently for items' +
-                        ' in the batch. These columns must have the same' +
-                        ' names as the corresponding arguments. See the ' +
-                        ' usage recipes at https://cw-geodata.readthedocs.io' +
+                        help='The reference file for variable values for'
+                        ' batch processing. It must contain columns to pass'
+                        ' the source_file and reference_image arguments, and'
+                        ' can additionally contain columns providing the'
+                        ' footprint_column and decimal_precision arguments'
+                        ' if you wish to define them differently for items'
+                        ' in the batch. These columns must have the same'
+                        ' names as the corresponding arguments. See the '
+                        ' usage recipes at https://cw-geodata.readthedocs.io'
                         ' for examples.')
     parser.add_argument('--workers', '-w', type=int, default=1,
-                        help='The number of parallel processing workers to' +
-                        ' use. This should not exceed the number of CPU' +
+                        help='The number of parallel processing workers to'
+                        ' use. This should not exceed the number of CPU'
                         ' cores available.')
 
     args = parser.parse_args()
@@ -140,6 +144,7 @@ def main():
         arg_df['output_path'] = [args.output_path]
         arg_df['geometry_column'] = [args.geometry_column]
         arg_df['transform'] = [args.transform]
+        arg_df['metric'] = [args.metric_widths]
         arg_df['value'] = [args.value]
         arg_df['edge_width'] = [args.edge_width]
         arg_df['edge_type'] = [args.edge_type]

--- a/solaris/bin/spacenet_eval.py
+++ b/solaris/bin/spacenet_eval.py
@@ -1,10 +1,9 @@
 """Script for executing eval for SpaceNet challenges."""
-from __future__ import print_function, with_statement, division
 from ..eval.challenges import off_nadir_buildings
 from ..eval.challenges import spacenet_buildings_2
 import argparse
 import pandas as pd
-supported_challenges = ['off-nadir', 'spaceNet-buildings2']
+supported_challenges = ['off-nadir', 'spacenet-buildings2']
 # , 'spaceNet-buildings1', 'spacenet-roads1', 'buildings', 'roads']
 
 

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -2,7 +2,7 @@ from ..utils.core import _check_df_load, _check_geom
 from ..utils.core import _check_skimage_im_load, _check_rasterio_im_load
 from ..utils.geo import gdf_get_projection_unit, reproject
 from ..utils.geo import geometries_internal_intersection
-from .polygon import georegister_px_df
+from .polygon import georegister_px_df, geojson_to_px_gdf, affine_transform_gdf
 import numpy as np
 from shapely.geometry import shape
 import geopandas as gpd
@@ -161,8 +161,7 @@ def footprint_mask(df, out_file=None, reference_im=None, geom_col='geometry',
         Affine transformation to use to convert from geo coordinates to pixel
         space. Only provide this argument if `df` is a
         :class:`geopandas.GeoDataFrame` with coordinates in a georeferenced
-        coordinate space. Ignored if `reference_im` is provided or if
-        ``do_transform=None``.
+        coordinate space. Ignored if `reference_im` is provided.
     shape : tuple, optional
         An ``(x_size, y_size)`` tuple defining the pixel extent of the output
         mask. Ignored if `reference_im` is provided.
@@ -258,7 +257,7 @@ def boundary_mask(footprint_msk=None, out_file=None, reference_im=None,
         affine transformation matrix, the image extent, etc. If provided,
         `affine_obj` and `shape` are ignored
     boundary_width : int, optional
-        The width of the boundary to be created in pixels. Defaults to 3.
+        The width of the boundary to be created **in pixels.** Defaults to 3.
     boundary_type : ``"inner"`` or ``"outer"``, optional
         Where to draw the boundaries: within the object (``"inner"``) or
         outside of it (``"outer"``). Defaults to ``"inner"``.
@@ -309,9 +308,10 @@ def boundary_mask(footprint_msk=None, out_file=None, reference_im=None,
     return output_arr
 
 
-def contact_mask(df, out_file=None, reference_im=None, geom_col='geometry',
+def contact_mask(df, contact_spacing=10, meters=False, out_file=None,
+                 reference_im=None, geom_col='geometry',
                  do_transform=None, affine_obj=None, shape=(900, 900),
-                 out_type='int', contact_spacing=10, burn_value=255):
+                 out_type='int', burn_value=255):
     """Create a pixel mask labeling closely juxtaposed objects.
 
     Notes
@@ -326,6 +326,15 @@ def contact_mask(df, out_file=None, reference_im=None, geom_col='geometry',
         with a column containing geometries (identified by `geom_col`). If the
         geometries in `df` are not in pixel coordinates, then `affine` or
         `reference_im` must be passed to provide the transformation to convert.
+    contact_spacing : `int` or `float`, optional
+        The desired maximum distance between adjacent polygons to be labeled
+        as contact. Will be in pixel units unless ``meters=True`` is provided.
+    meters : bool, optional
+        Should `width` be defined in units of meters? Defaults to no
+        (``False``). If ``True`` and `df` is not in a CRS with metric units,
+        the function will attempt to transform to the relevant CRS using
+        ``df.to_crs()`` (if `df` is a :class:`geopandas.GeoDataFrame`) or
+        using the data provided in `reference_im` (if not).
     out_file : str, optional
         Path to an image file to save the output to. Must be compatible with
         :class:`rasterio.DatasetReader`. If provided, a `reference_im` must be
@@ -352,10 +361,6 @@ def contact_mask(df, out_file=None, reference_im=None, geom_col='geometry',
         An ``(x_size, y_size)`` tuple defining the pixel extent of the output
         mask. Ignored if `reference_im` is provided.
     out_type : 'float' or 'int'
-    contact_spacing : `int` or `float`, optional
-        The desired maximum distance between adjacent polygons to be labeled
-        as contact. `contact_spacing` will be in the same units as `df` 's
-        geometries, not necessarily in pixel units.
     burn_value : `int` or `float`, optional
         The value to use for labeling objects in the mask. Defaults to 255 (the
         max value for ``uint8`` arrays). The mask array will be set to the same
@@ -378,8 +383,10 @@ def contact_mask(df, out_file=None, reference_im=None, geom_col='geometry',
     df[geom_col] = df[geom_col].apply(_check_geom)  # load in geoms if wkt
     if reference_im:
         reference_im = _check_rasterio_im_load(reference_im)
-    # grow geometries by half `contact_spacing` to find overlaps
-    buffered_geoms = df[geom_col].apply(lambda x: x.buffer(contact_spacing/2))
+    buffered_geoms = buffer_df_geoms(df, contact_spacing/2., meters=meters,
+                                     reference_im=reference_im,
+                                     geom_col=geom_col, affine_obj=affine_obj)
+    buffered_geoms = buffered_geoms[geom_col]
     # create a single multipolygon that covers all of the intersections
     intersect_poly = geometries_internal_intersection(buffered_geoms)
     # create a small df containing the intersections to make a footprint from
@@ -409,6 +416,219 @@ def contact_mask(df, out_file=None, reference_im=None, geom_col='geometry',
             dst.write(output_arr, indexes=1)
 
     return output_arr
+
+
+def road_mask(df, width=8, meters=False, out_file=None, reference_im=None,
+              geom_col='geometry', do_transform=None, affine_obj=None,
+              shape=(900, 900), out_type='int', burn_value=255,
+              burn_field=None, min_background_value=None, verbose=False):
+    """Convert a dataframe of geometries to a pixel mask.
+
+    Arguments
+    ---------
+    df : :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame`
+        A :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame` instance
+        with a column containing geometries (identified by `geom_col`). If the
+        geometries in `df` are not in pixel coordinates, then `affine` or
+        `reference_im` must be passed to provide the transformation to convert.
+    width : `float` or `int`, optional
+        The total width to make a road (i.e. twice x if using
+        road.buffer(x)). In pixel units unless `meters` is ``True``.
+    meters : bool, optional
+        Should `width` be defined in units of meters? Defaults to no
+        (``False``). If ``True`` and `df` is not in a CRS with metric units,
+        the function will attempt to transform to the relevant CRS using
+        ``df.to_crs()`` (if `df` is a :class:`geopandas.GeoDataFrame`) or
+        using the data provided in `reference_im` (if not).
+    out_file : str, optional
+        Path to an image file to save the output to. Must be compatible with
+        :class:`rasterio.DatasetReader`. If provided, a `reference_im` must be
+        provided (for metadata purposes).
+    reference_im : :class:`rasterio.DatasetReader` or `str`, optional
+        An image to extract necessary coordinate information from: the
+        affine transformation matrix, the image extent, etc. If provided,
+        `affine_obj` and `shape` are ignored.
+    geom_col : str, optional
+        The column containing geometries in `df`. Defaults to ``"geometry"``.
+    do_transform : bool, optional
+        Should the values in `df` be transformed from geospatial coordinates
+        to pixel coordinates? Defaults to ``None``, in which case the function
+        attempts to infer whether or not a transformation is required based on
+        the presence or absence of a CRS in `df`. If ``True``, either
+        `reference_im` or `affine_obj` must be provided as a source for the
+        the required affine transformation matrix.
+    affine_obj : `list` or :class:`affine.Affine`, optional
+        Affine transformation to use to convert from geo coordinates to pixel
+        space. Only provide this argument if `df` is a
+        :class:`geopandas.GeoDataFrame` with coordinates in a georeferenced
+        coordinate space. Ignored if `reference_im` is provided.
+    shape : tuple, optional
+        An ``(x_size, y_size)`` tuple defining the pixel extent of the output
+        mask. Ignored if `reference_im` is provided.
+    out_type : 'float' or 'int'
+    burn_value : `int` or `float`, optional
+        The value to use for labeling objects in the mask. Defaults to 255 (the
+        max value for ``uint8`` arrays). The mask array will be set to the same
+        dtype as `burn_value`. Ignored if `burn_field` is provided.
+    burn_field : str, optional
+        Name of a column in `df` that provides values for `burn_value` for each
+        independent object. If provided, `burn_value` is ignored.
+    min_background_val : int
+        Minimum value for mask background. Optional, ignore if ``None``.
+        Defaults to ``None``.
+    verbose : str, optional
+        Switch to print relevant values. Defaults to ``False``.
+
+    Returns
+    -------
+    mask : :class:`numpy.array`
+        A pixel mask with 0s for non-object pixels and `burn_value` at object
+        pixels. `mask` dtype will coincide with `burn_value`.
+    """
+
+    # start with required checks and pre-population of values
+    if out_file and not reference_im:
+        raise ValueError(
+            'If saving output to file, `reference_im` must be provided.')
+    df = _check_df_load(df)
+    df[geom_col] = df[geom_col].apply(_check_geom)  # ensure WKTs are loaded
+
+    buffered_df = buffer_df_geoms(df, width/2., meters=meters,
+                                  reference_im=reference_im, geom_col=geom_col,
+                                  affine_obj=affine_obj)
+
+    if do_transform is None:
+        # determine whether or not transform should be done
+        do_transform = _check_do_transform(df, reference_im, affine_obj)
+
+    if not do_transform:
+        affine_obj = Affine(1, 0, 0, 0, 1, 0)  # identity transform
+
+    if reference_im:
+        reference_im = _check_rasterio_im_load(reference_im)
+        shape = reference_im.shape
+        if do_transform:
+            affine_obj = reference_im.transform
+
+    # extract geometries and pair them with burn values
+    if burn_field:
+        if out_type == 'int':
+            feature_list = list(zip(buffered_df[geom_col],
+                                    buffered_df[burn_field].astype('uint8')))
+        else:
+            feature_list = list(zip(buffered_df[geom_col],
+                                    buffered_df[burn_field].astype('uint8')))
+    else:
+        feature_list = list(zip(buffered_df[geom_col],
+                                [burn_value] * len(buffered_df)))
+
+    output_arr = features.rasterize(shapes=feature_list, out_shape=shape,
+                                    transform=affine_obj)
+    if min_background_value:
+        output_arr = np.clip(output_arr, min_background_value,
+                             np.max(output_arr))
+
+    if out_file:
+        meta = reference_im.meta.copy()
+        meta.update(count=1)
+        if out_type == 'int':
+            meta.update(dtype='uint8')
+        with rasterio.open(out_file, 'w', **meta) as dst:
+            dst.write(output_arr, indexes=1)
+
+    return output_arr
+
+
+def buffer_df_geoms(df, buffer, meters=False, reference_im=None,
+                    geom_col='geometry', affine_obj=None):
+    """Buffer geometries within a pd.DataFrame or gpd.GeoDataFrame.
+
+    Arguments
+    ---------
+    df : :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame`
+        A :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame` instance
+        with a column containing geometries (identified by `geom_col`). If `df`
+        lacks a ``crs`` attribute (isn't a :class:`geopandas.GeoDataFrame` )
+        and ``meters=True``, then `reference_im` must be provided for
+        georeferencing.
+    buffer : `int` or `float`
+        The amount to buffer the geometries in `df`. In pixel units unless
+        ``meters=True``. This corresponds to width/2 in mask creation
+        functions.
+    meters : bool, optional
+        Should buffers be in pixel units (default) or metric units (if `meters`
+        is ``True``)?
+    reference_im : `str` or :class:`rasterio.DatasetReader`, optional
+        The path to a reference image covering the same geographic extent as
+        the area labeled in `df`. Provided for georeferencing of pixel
+        coordinate geometries in `df` or conversion of georeferenced geometries
+        to pixel coordinates as needed. Required if `meters` is ``True`` and
+        `df` lacks a ``crs`` attribute.
+    geom_col : str, optional
+        The column containing geometries in `df`. Defaults to ``"geometry"``.
+    affine_obj : `list` or :class:`affine.Affine`, optional
+        Affine transformation to use to convert geoms in `df` from a geographic
+        crs to pixel space. Only provide this argument if `df` is a
+        :class:`geopandas.GeoDataFrame` with coordinates in a georeferenced
+        coordinate space. Ignored if `reference_im` is provided.
+
+    Returns
+    -------
+    buffered_df : :class:`pandas.DataFrame`
+        A :class:`pandas.DataFrame` in the original coordinate reference system
+        with objects buffered per `buffer`.
+    """
+    if reference_im is not None:
+        reference_im = _check_rasterio_im_load(reference_im)
+
+    if hasattr(df, 'crs'):
+        orig_crs = df.crs
+    else:
+        orig_crs = None  # will represent pixel crs
+
+    # Check if dataframe is in the appropriate units and reproject if not
+    if not meters:
+        if hasattr(df, 'crs') and reference_im is not None:
+            # if the df is georeferenced and a reference_im is provided,
+            # use reference_im to transform df to px coordinates
+            df_for_buffer = geojson_to_px_gdf(df, reference_im)
+        elif hasattr(df, 'crs') and reference_im is None:
+            df_for_buffer = affine_transform_gdf(df, affine_obj=affine_obj)
+        else:  # if it's already in px coordinates
+            df_for_buffer = df
+
+    else:
+        # check if the df is in a metric crs
+        if hasattr(df, 'crs'):
+            if crs_is_metric(df):
+                df_for_buffer = df
+            else:
+                df_for_buffer = reproject(df)  # defaults to UTM
+        else:
+            # assume df is in px coords - use reference_im to georegister
+            if reference_im is not None:
+                df_for_buffer = georegister_px_df(df, im_path=reference_im)
+            else:
+                raise ValueError('If using `meters=True`, either `df` must be '
+                                 'a geopandas GeoDataFrame or `reference_im` '
+                                 'must be provided for georegistration.')
+
+    df_for_buffer[geom_col] = df_for_buffer[geom_col].apply(
+        lambda x: x.buffer(buffer))
+
+    # return to original crs
+    if getattr(df_for_buffer, 'crs') != orig_crs:
+        if orig_crs is not None and getattr(df_for_buffer, 'crs') is not None:
+            buffered_df = df_for_buffer.to_crs(orig_crs)
+        elif orig_crs is None:  # but df_for_buffer has one: meters=True case
+            buffered_df = geojson_to_px_gdf(df_for_buffer, reference_im)
+        else:  # orig_crs exists, but df_for_buffer doesn't have one
+            buffered_df = georegister_px_df(df_for_buffer,
+                                            im_path=reference_im,
+                                            affine_obj=affine_obj,
+                                            crs=orig_crs)
+
+    return buffered_df
 
 
 def mask_to_poly_geojson(mask_arr, reference_im=None, output_path=None,
@@ -491,144 +711,14 @@ def mask_to_poly_geojson(mask_arr, reference_im=None, output_path=None,
     return polygon_gdf
 
 
-def road_mask(df, out_file=None, reference_im=None, geom_col='geometry',
-              do_transform=None, affine_obj=None, shape=(900, 900),
-              buffer_in_m=2, out_type='int', burn_value=255, burn_field=None,
-              min_background_value=None, verbose=False):
-    """Convert a dataframe of geometries to a pixel mask.
-
-    Arguments
-    ---------
-    df : :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame`
-        A :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame` instance
-        with a column containing geometries (identified by `geom_col`). If the
-        geometries in `df` are not in pixel coordinates, then `affine` or
-        `reference_im` must be passed to provide the transformation to convert.
-    out_file : str, optional
-        Path to an image file to save the output to. Must be compatible with
-        :class:`rasterio.DatasetReader`. If provided, a `reference_im` must be
-        provided (for metadata purposes).
-    reference_im : :class:`rasterio.DatasetReader` or `str`, optional
-        An image to extract necessary coordinate information from: the
-        affine transformation matrix, the image extent, etc. If provided,
-        `affine_obj` and `shape` are ignored.
-    geom_col : str, optional
-        The column containing geometries in `df`. Defaults to ``"geometry"``.
-    do_transform : bool, optional
-        Should the values in `df` be transformed from geospatial coordinates
-        to pixel coordinates? Defaults to ``None``, in which case the function
-        attempts to infer whether or not a transformation is required based on
-        the presence or absence of a CRS in `df`. If ``True``, either
-        `reference_im` or `affine_obj` must be provided as a source for the
-        the required affine transformation matrix.
-    affine_obj : `list` or :class:`affine.Affine`, optional
-        Affine transformation to use to convert from geo coordinates to pixel
-        space. Only provide this argument if `df` is a
-        :class:`geopandas.GeoDataFrame` with coordinates in a georeferenced
-        coordinate space. Ignored if `reference_im` is provided or if
-        ``do_transform=None``.
-    shape : tuple, optional
-        An ``(x_size, y_size)`` tuple defining the pixel extent of the output
-        mask. Ignored if `reference_im` is provided.
-    buffer_in_m : 'float' or 'int'
-        The amount to buffer a roadway linestring on either side in meters.
-        For example a value == 2 will create a roadway 4 meters in total width
-        around the centerline.
-    out_type : 'float' or 'int'
-    burn_value : `int` or `float`, optional
-        The value to use for labeling objects in the mask. Defaults to 255 (the
-        max value for ``uint8`` arrays). The mask array will be set to the same
-        dtype as `burn_value`. Ignored if `burn_field` is provided.
-    burn_field : str, optional
-        Name of a column in `df` that provides values for `burn_value` for each
-        independent object. If provided, `burn_value` is ignored.
-    min_background_val : int
-        Minimum value for mask background. Optional, ignore if ``None``.
-        Defaults to ``None``.
-    verbose : str, optional
-        Switch to print relevant values. Defaults to ``False``.
-
-    Returns
-    -------
-    mask : :class:`numpy.array`
-        A pixel mask with 0s for non-object pixels and `burn_value` at object
-        pixels. `mask` dtype will coincide with `burn_value`.
-    """
-
-    # start with required checks and pre-population of values
-    if out_file and not reference_im:
-        raise ValueError(
-            'If saving output to file, `reference_im` must be provided.')
-    df = _check_df_load(df)
-    df[geom_col] = df[geom_col].apply(_check_geom)
-
-    if not hasattr(df, 'crs'):  # if it's not a geodataframe
-        # georegister with reference_im
-        if reference_im is None:
-            raise ValueError(
-                'If the input geometries lack a geospatial CRS, a'
-                'georegistered image must be provided.'
-            )
-        df = georegister_px_df(df, im_path=reference_im)
-
-    orig_crs = df.crs
-
-    if do_transform is None:
-        # determine whether or not transform should be done
-        do_transform = _check_do_transform(df, reference_im, affine_obj)
-
-    # Check if dataframe is in the appropriate units (meters, metres
-    # and reproject if not)
-    unit = str(gdf_get_projection_unit(df)).strip()
-    if verbose:
-        print("unit:", unit)
-    if unit not in ['"meter"', '"metre"', "'meter'", "'meter'",
-                    'meter', 'metre']:
-        # Pick UTM zone
-        df = reproject(df)  # defaults to UTM
-        df[geom_col] = df[geom_col].apply(lambda x: x.buffer(buffer_in_m))
-        # Send back to old CRS
-        df = df.to_crs(orig_crs)
-
+def crs_is_metric(gdf):
+    """Check if a GeoDataFrame's CRS is in metric units."""
+    units = str(gdf_get_projection_unit(gdf)).strip().lower()
+    if units in ['"meter"', '"metre"', "'meter'", "'meter'",
+                 'meter', 'metre']:
+        return True
     else:
-        df[geom_col] = df[geom_col].apply(lambda x: x.buffer(buffer_in_m))
-
-    # load in geoms if wkt
-    if not do_transform:
-        affine_obj = Affine(1, 0, 0, 0, 1, 0)  # identity transform
-
-    if reference_im:
-        reference_im = _check_rasterio_im_load(reference_im)
-        shape = reference_im.shape
-        if do_transform:
-            affine_obj = reference_im.transform
-
-    # extract geometries and pair them with burn values
-    if burn_field:
-        if out_type == 'int':
-            feature_list = list(zip(df[geom_col],
-                                    df[burn_field].astype('uint8')))
-        else:
-            feature_list = list(zip(df[geom_col],
-                                    df[burn_field].astype('uint8')))
-    else:
-        feature_list = list(zip(df[geom_col], [burn_value] * len(df)))
-
-    output_arr = features.rasterize(shapes=feature_list, out_shape=shape,
-                                    transform=affine_obj)
-    if min_background_value:
-        output_arr = np.clip(output_arr, min_background_value,
-                             np.max(output_arr))
-
-    if out_file:
-        meta = reference_im.meta.copy()
-        meta.update(count=1)
-        if out_type == 'int':
-            meta.update(dtype='uint8')
-        with rasterio.open(out_file, 'w', **meta) as dst:
-            dst.write(output_arr, indexes=1)
-
-    return output_arr
+        return False
 
 
 def _check_do_transform(df, reference_im, affine_obj):

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -3,8 +3,9 @@ import shapely
 from affine import Affine
 import rasterio
 from rasterio.warp import transform_bounds
+from rasterio.crs import CRS
 from ..utils.geo import list_to_affine, _reduce_geom_precision
-from ..utils.core import _check_gdf_load
+from ..utils.core import _check_gdf_load, _check_crs, _check_rasterio_im_load
 from ..raster.image import get_geo_transform
 from shapely.geometry import box, Polygon
 import pandas as pd
@@ -129,6 +130,10 @@ def affine_transform_gdf(gdf, affine_obj, inverse=False, geom_col="geometry",
     if precision is not None:
         gdf['geometry'] = gdf['geometry'].apply(
             _reduce_geom_precision, precision=precision)
+
+    # the CRS is no longer valid - remove it
+    gdf.crs = None
+
     return gdf
 
 
@@ -149,10 +154,10 @@ def georegister_px_df(df, im_path=None, affine_obj=None, crs=None,
         An affine transformation to apply to `geom` in the form of an
         ``[a, b, d, e, xoff, yoff]`` list or an :class:`affine.Affine` object.
         Required if not using `raster_src`.
-    crs : dict, optional
-        The coordinate reference system for the output GeoDataFrame. Required
-        if not providing a raster image to extract the information from. Format
-        should be ``{'init': 'epsgxxxx'}``, replacing xxxx with the EPSG code.
+    crs : int
+        The coordinate reference system for the output GeoDataFrame as an EPSG
+        code integer. Required if not providing a raster image to extract the
+        information from.
     geom_col : str, optional
         The column containing geometry in `df`. If not provided, defaults to
         ``"geometry"``.
@@ -165,16 +170,17 @@ def georegister_px_df(df, im_path=None, affine_obj=None, crs=None,
 
     """
     if im_path is not None:
-        affine_obj = rasterio.open(im_path).transform
-        crs = rasterio.open(im_path).crs
+        im = _check_rasterio_im_load(im_path)
+        affine_obj = im.transform
+        crs = im.crs
     else:
         if not affine_obj or not crs:
-            raise ValueError(
-                'If an image path is not provided, ' +
-                'affine_obj and crs must be.')
+            raise ValueError('If an image path is not provided, '
+                             'affine_obj and crs must be.')
+    crs = _check_crs(crs)
     tmp_df = affine_transform_gdf(df, affine_obj, geom_col=geom_col,
                                   precision=precision)
-    result = gpd.GeoDataFrame(tmp_df, crs=crs)
+    result = gpd.GeoDataFrame(tmp_df, crs='epsg:' + str(crs))
 
     if output_path is not None:
         if output_path.lower().endswith('json'):
@@ -197,9 +203,7 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
         column named ``'geometry'`` in this argument.
     im_path : str
         Path to a georeferenced image (ie a GeoTIFF) that geolocates to the
-        same geography as the `geojson`(s). If a directory, the bounds of each
-        GeoTIFF will be loaded in and all overlapping geometries will be
-        transformed. This function will also accept a
+        same geography as the `geojson`(s). This function will also accept a
         :class:`osgeo.gdal.Dataset` or :class:`rasterio.DatasetReader` with
         georeferencing information in this argument.
     geom_col : str, optional
@@ -222,20 +226,12 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
 
     """
     # get the bbox and affine transforms for the image
-    if isinstance(im_path, str):
-        bbox = box(*rasterio.open(im_path).bounds)
-        affine_obj = rasterio.open(im_path).transform
-        im_crs = rasterio.open(im_path).crs
-
-    else:
-        bbox = box(im_path.bounds)
-        affine_obj = im_path.transform
-        im_crs = im_path.crs
-
+    im = _check_rasterio_im_load(im_path)
     # make sure the geo vector data is loaded in as geodataframe(s)
     gdf = _check_gdf_load(geojson)
+    overlap_gdf = get_overlapping_subset(gdf, im)
 
-    overlap_gdf = get_overlapping_subset(gdf, bbox=bbox, bbox_crs=im_crs)
+    affine_obj = im.transform
     transformed_gdf = affine_transform_gdf(overlap_gdf, affine_obj=affine_obj,
                                            inverse=True, precision=precision,
                                            geom_col=geom_col)
@@ -271,6 +267,10 @@ def get_overlapping_subset(gdf, im=None, bbox=None, bbox_crs=None):
         `bbox` is passed and `im` is not, a `bbox_crs` should be provided to
         ensure correct geolocation - if it isn't, it will be assumed to have
         the same crs as `gdf`.
+    bbox_crs : int, optional
+        The coordinate reference system that the bounding box is in as an EPSG
+        int. If not provided, it's assumed that the CRS is the same as `im`
+        (if provided) or `gdf` (if not).
 
     Returns
     -------
@@ -280,22 +280,27 @@ def get_overlapping_subset(gdf, im=None, bbox=None, bbox_crs=None):
         Coordinates are kept in the CRS of `gdf`.
 
     """
-    if not im and not bbox:
+    if im is None and bbox is None:
         raise ValueError('Either `im` or `bbox` must be provided.')
-    if isinstance(gdf, str):
-        gdf = gpd.read_file(gdf)
-    if isinstance(im, str):
-        im = rasterio.open(im)
+    gdf = _check_gdf_load(gdf)
     sindex = gdf.sindex
-    # use transform_bounds in case the crs is different - no effect if not
-    if im:
+    if im is not None:
+        im = _check_rasterio_im_load(im)
         bbox = transform_bounds(im.crs, gdf.crs, *im.bounds)
-    else:
-        if isinstance(bbox, Polygon):
-            bbox = bbox.bounds
-        if not bbox_crs:
+        bbox_crs = im.crs
+    # use transform_bounds in case the crs is different - no effect if not
+    if isinstance(bbox, Polygon):
+        bbox = bbox.bounds
+    if bbox_crs is None:
+        try:
             bbox_crs = gdf.crs
-        bbox = transform_bounds(bbox_crs, gdf.crs, *bbox)
+        except AttributeError:
+            raise ValueError('If `im` and `bbox_crs` are not provided, `gdf`'
+                             'must provide a coordinate reference system.')
+    else:
+        bbox_crs = _check_crs(bbox_crs)
+        bbox_crs = CRS.from_epsg(bbox_crs)
+    bbox = transform_bounds(bbox_crs, gdf.crs, *bbox)
     try:
         intersectors = list(sindex.intersection(bbox))
     except RTreeError:

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -227,6 +227,8 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
     """
     # get the bbox and affine transforms for the image
     im = _check_rasterio_im_load(im_path)
+    if isinstance(im_path, rasterio.DatasetReader):
+        im_path = im_path.name
     # make sure the geo vector data is loaded in as geodataframe(s)
     gdf = _check_gdf_load(geojson)
     overlap_gdf = get_overlapping_subset(gdf, im)

--- a/tests/test_eval/spacenet_buildings2_dataset_test.py
+++ b/tests/test_eval/spacenet_buildings2_dataset_test.py
@@ -47,7 +47,7 @@ class TestEvalCLISN2(object):
                                  'SN2_sample_truth.csv')
         subprocess.call(['spacenet_eval', '--proposal_csv='+proposal_csv,
                          '--truth_csv='+truth_csv,
-                         '--challenge=spaceNet-buildings2',
+                         '--challenge=spacenet-buildings2',
                          '--output_file=test_out'])
         test_results = pd.read_csv('test_out.csv')
         full_test_results = pd.read_csv('test_out_full.csv')

--- a/tests/test_vector/test_mask.py
+++ b/tests/test_vector/test_mask.py
@@ -246,7 +246,7 @@ class TestRoadMask(object):
         output_mask = road_mask(
             os.path.join(data_dir, 'sample_roads_for_masking.geojson'),
             reference_im=os.path.join(data_dir, 'road_mask_input.tif'),
-            do_transform=True,
+            width=4, meters=True, do_transform=True,
             out_file=os.path.join(data_dir, 'test_out.tif')
             )
         truth_mask = skimage.io.imread(


### PR DESCRIPTION
Thank you for submitting your PR. Please read the template below, fill it out as appropriate, and make additional changes to your code as needed. Please feel free to submit your PR even if it doesn't satisfy all of the requirements below - simply prepend [WIP] to the PR title until it is ready for review by a maintainer. If you need assistance or review from a maintainer, add the label __Status: Help Needed__ or __Status: Review Needed__ respectively. After review, a maintainer will add the label __Status: Revision Needed__ if further work is required for the PR to be merged.

# Description

- __standardized buffering across mask creation functions__: added an argument, `meters=False`, to each function that uses a buffer. By default, each of these functions will perform buffering in pixel units; providing the argument `meters=True` forces metric units for buffering. Confirmed that both versions work in the pytests (tested pixel units for `contact_mask()` and metric units for `road_mask()`; not ideal to split this way but covers the functionality anyway).
- __pulled buffering out of the functions doing it__: ensured buffering happens in a standardized fashion by pulling it out into a separate function, `solaris.vector.mask.buffer_df_geoms()`, and called it from `road_mask()` and `contact_mask()`.
- __CLI__: added an argument to the masking CLI entrypoint to enable setting metric buffers.

Fixes #134 

## Type of change

Please delete options that are not relevant.

Maintenance


# How Has This Been Tested?

Please describe tests that you added to the pytest codebase (if applicable).

# Checklist:

- [x] My PR has a descriptive title
- [x] My code follows PEP8
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
