### PR TITLE
ISS247: Refactor and clarify data generators

### DIFF
--- a/solaris/nets/datagen.py
+++ b/solaris/nets/datagen.py
@@ -1,13 +1,20 @@
 from tensorflow import keras
 import numpy as np
 from torch.utils.data import Dataset, DataLoader
-from .transform import process_aug_dict
+from .transform import _check_augs, process_aug_dict
 from ..utils.core import _check_df_load
 from ..utils.io import imread, _check_channel_order
 
 
 def make_data_generator(framework, config, df, stage='train'):
     """Create an appropriate data generator based on the framework used.
+
+    A wrapper for the high-end ``solaris`` API to create data generators.
+    Using the ``config`` dictionary, this function creates an instance of
+    either :class:`KerasSegmentationSequence` or :class:`TorchDataset`
+    (depending on the framework used for the pipeline). If using Torch, this
+    instance is then wrapped in a :class:`torch.utils.data.DataLoader` and
+    returned; if Keras, the sequence object is directly returned.
 
     Arguments
     ---------
@@ -20,116 +27,183 @@ def make_data_generator(framework, config, df, stage='train'):
         A :class:`pandas.DataFrame` containing two columns: ``'image'``, with
         the path to images for training, and ``'label'``, with the path to the
         label file corresponding to each image.
+    stage : str, optional
+        Either ``'train'`` or ``'validate'``, indicates whether the object
+        created is being used for training or validation. This determines which
+        augmentations from the config file are applied within the returned
+        object.
 
     Returns
     -------
-    A Keras, PyTorch, TensorFlow, or TensorFlow Object Detection API object
-    to feed data during model training or inference.
+    data_gen : :class:`KerasSegmentationSequence` or :class:`torch.utils.data.DataLoader`
+        An object to pass data into the :class:`solaris.nets.train.Trainer`
+        instance during model training.
+
+    See Also
+    --------
+    :class:`KerasSegmentationSequence`
+    :class:`TorchDataset`
+    :class:`InferenceTiler`
     """
 
-    if framework.lower() not in ['keras', 'pytorch', 'torch',
-                                 'simrdwn', 'tf', 'tf_obj_api']:
+    if framework.lower() not in ['keras', 'pytorch', 'torch']:
         raise ValueError('{} is not an accepted value for `framework`'.format(
             framework))
 
     # make sure the df is loaded
     df = _check_df_load(df)
 
+    if stage == 'train':
+        augs = config['training_augmentation']
+        shuffle = config['training_augmentation']['shuffle']
+    elif stage == 'validate':
+        augs = config['validation_augmentation']
+        shuffle = False
+
     if framework.lower() == 'keras':
-        return KerasSegmentationSequence(config, df, stage=stage)
+        data_gen = KerasSegmentationSequence(
+            df,
+            height=config['data_specs']['height'],
+            width=config['data_specs']['width'],
+            input_channels=config['data_specs']['channels'],
+            output_channels=config['data_specs']['mask_channels'],
+            augs=augs,
+            batch_size=config['batch_size'],
+            label_type=config['data_specs']['label_type'],
+            is_categorical=config['data_specs']['is_categorical'],
+            shuffle=shuffle)
 
     elif framework in ['torch', 'pytorch']:
-        dataset = TorchDataset(config, df, stage)
+        dataset = TorchDataset(
+            df,
+            augs=augs,
+            batch_size=config['batch_size'],
+            label_type=config['data_specs']['label_type'],
+            is_categorical=config['data_specs']['is_categorical'],
+            dtype=config['data_specs']['dtype'])
         # set up workers for DataLoader for pytorch
         data_workers = config['data_specs'].get('data_workers')
         if data_workers == 1 or data_workers is None:
             data_workers = 0  # for DataLoader to run in main process
-        return DataLoader(dataset, batch_size=config['batch_size'],
-                          shuffle=config['training_augmentation']['shuffle'],
-                          num_workers=data_workers)
+        data_gen = DataLoader(
+            dataset,
+            batch_size=config['batch_size'],
+            shuffle=config['training_augmentation']['shuffle'],
+            num_workers=data_workers)
+
+    return data_gen
 
 
 class KerasSegmentationSequence(keras.utils.Sequence):
-    # TODO: DOCUMENT!
-    def __init__(self, config, df, stage='train'):
-        self.config = config
-        # TODO: IMPLEMENT LOADING IN AUGMENTATION PIPELINE HERE!
+    """An object to stream images from files into a Keras model in solaris.
+
+
+    Attributes
+    ----------
+    df : :class:`pandas.DataFrame`
+        The :class:`pandas.DataFrame` specifying where inputs are stored.
+    height : int
+        The height of generated images.
+    width : int
+        The width of generated images.
+    input_channels : int
+        The number of channels in generated inputs.
+    output_channels : int
+        The number of channels in target masks created.
+    aug : :class:`albumentations.core.composition.Compose`
+        An albumentations Compose object to pass imagery through before
+        passing it into the neural net. If an augmentation config subdict
+        was provided during initialization, this is created by parsing the
+        dict with :func:`solaris.nets.transform.process_aug_dict`.
+    batch_size : int
+        The batch size generated.
+    n_batches : int
+        The number of batches per epoch. Inferred based on the number of
+        input files in `df` and `batch_size`.
+    label_type : str
+        Type of labels. Currently always ``"mask"``.
+    is_categorical : bool
+        Indicates whether masks output are boolean or categorical labels.
+    shuffle : bool
+        Indicates whether or not input order is shuffled for each epoch.
+    """
+
+    def __init__(self, df, height, width, input_channels, output_channels,
+                 augs, batch_size, label_type='mask', is_categorical=False,
+                 shuffle=True):
+        """Create an instance of KerasSegmentationSequence.
+
+        Arguments
+        ---------
+        df : :class:`pandas.DataFrame`
+            A pandas DataFrame specifying images and label files to read into
+            the model. See `the reference file creation tutorial`_ for more.
+        height : int
+            The height of model inputs in pixels.
+        width : int
+            The width of model inputs in pixels.
+        input_channels : int
+            The number of channels in model input imagery.
+        output_channels : int
+            The number of channels in the model output.
+        augs : :class:`dict` or :class:`albumentations.core.composition.Compose`
+            Either the config subdict specifying augmentations to apply, or
+            a pre-created :class:`albumentations.core.composition.Compose` object
+            containing all of the augmentations to apply.
+        batch_size : int
+            The number of samples in a training batch.
+        label_type : str, optional
+            The type of labels to be used. At present, only ``"mask"`` is
+            supported.
+        is_categorical : bool, optional
+            Is the data categorical or boolean (default)?
+        shuffle : bool, optional
+            Should image order be shuffled in each epoch?
+
+
+        .. _the reference file creation tutorial: https://solaris.readthedocs.io/en/latest/tutorials/notebooks/creating_im_reference_csvs.html
+        """
+
         # TODO: IMPLEMENT GETTING INPUT FILE LISTS HERE!
-        self.batch_size = self.config['batch_size']
         self.df = df
+        self.height = height
+        self.width = width
+        self.input_channels = input_channels
+        self.output_channels = output_channels
+        self.aug = _check_augs(augs)  # checks if they're loaded; loads if not
+        self.batch_size = batch_size
         self.n_batches = int(np.floor(len(self.df)/self.batch_size))
-        if stage == 'train':
-            self.aug = process_aug_dict(self.config['training_augmentation'])
-        elif stage == 'validate':
-            self.aug = process_aug_dict(self.config['validation_augmentation'])
+        self.label_type = label_type
+        self.is_categorical = is_categorical
+        self.shuffle = shuffle
         self.on_epoch_end()
 
     def on_epoch_end(self):
-        'Update indices, rotations, etc. after each epoch'
+        """Update indices after each epoch."""
         # reorder images
         self.image_indexes = np.arange(len(self.df))
-        if self.config['training_augmentation']['shuffle']:
+        if self.shuffle:
             np.random.shuffle(self.image_indexes)
-    #     if self.crop:
-    #         self.x_mins = np.random.randint(
-    #             0, self.image_shape[1]-self.output_x, size=self.batch_size
-    #         )
-    #         self.y_mins = np.random.randint(
-    #             0, self.image_shape[0] - self.output_y, size=self.batch_size
-    #         )
-    #     if self.flip_x:
-    #         self.x_flips = np.random.choice(
-    #             [False, True], size=self.batch_size
-    #         )
-    #     if self.flip_y:
-    #         self.y_flips = np.random.choice(
-    #             [False, True], size=self.batch_size
-    #         )
-    #     if self.rotate:
-    #         self.n_rotations = np.random.choice(
-    #             [0, 1, 2, 3], size=self.batch_size
-    #         )
-    #     if self.rescale_brightness is not None:
-    #         self.amt_to_scale = np.random.uniform(
-    #             low=self.rescale_brightness[0],
-    #             high=self.rescale_brightness[1],
-    #             size=self.batch_size
-    #         )
-    #     if self.zoom_range is not None:
-    #         if (1-self.zoom_range)*self.image_shape[0] < self.output_y:
-    #             self.zoom_range = self.output_y/self.image_shape[0]
-    #         if (1-self.zoom_range)*self.image_shape[1] < self.output_x:
-    #             self.zoom_range = self.output_x/self.image_shape[1]
-    #         self.zoom_amt_y = np.random.uniform(
-    #             low=1-self.zoom_range,
-    #             high=1+self.zoom_range,
-    #             size=self.batch_size
-    #         )
-    #         self.zoom_amt_x = np.random.uniform(
-    #             low=1-self.zoom_range,
-    #             high=1+self.zoom_range,
-    #             size=self.batch_size
-    #         )
 
     def _data_generation(self, image_idxs):
         # initialize the output array
         X = np.empty((self.batch_size,
-                      self.config['data_specs']['height'],
-                      self.config['data_specs']['width'],
-                      self.config['data_specs']['channels']))
-        if self.config['data_specs']['label_type'] == 'mask':
+                      self.height,
+                      self.width,
+                      self.input_channels))
+        if self.label_type == 'mask':
             y = np.empty((self.batch_size,
-                          self.config['data_specs']['height'],
-                          self.config['data_specs']['width'],
-                          self.config['data_specs']['mask_channels']))
+                          self.height,
+                          self.width,
+                          self.output_channels))
         else:
             pass  # TODO: IMPLEMENT BBOX LABEL SETUP HERE!
         for i in range(self.batch_size):
             im = imread(self.df['image'].iloc[image_idxs[i]])
             im = _check_channel_order(im, 'keras')
-            if self.config['data_specs']['label_type'] == 'mask':
+            if self.label_type == 'mask':
                 label = imread(self.df['label'].iloc[image_idxs[i]])
-                if not self.config['data_specs']['is_categorical']:
+                if not self.is_categorical:
                     label[label != 0] = 1
                 aug_result = self.aug(image=im, mask=label)
                 # if image shape is 2D, convert to 3D
@@ -146,11 +220,14 @@ class KerasSegmentationSequence(keras.utils.Sequence):
         return X, y
 
     def __len__(self):
-        'Denotes the number of batches per epoch'
+        """Denotes the number of batches per epoch.
+
+        This is a required method for Keras Sequence objects.
+        """
         return self.n_batches
 
     def __getitem__(self, index):
-        'Generate one batch of data'
+        """Generate one batch of data."""
         # Generate indexes of the batch
         im_inds = self.image_indexes[index*self.batch_size:
                                      (index+1)*self.batch_size]
@@ -161,47 +238,92 @@ class KerasSegmentationSequence(keras.utils.Sequence):
 
 
 class TorchDataset(Dataset):
-    """A PyTorch dataset object for segmentation/object detection.
+    """A PyTorch dataset object for solaris.
 
-    Arguments
-    ---------
-    config : dict
-        The configuration dictionary for the model run.
-    stage : str
-        The stage of model training/inference the `TorchDataset` will be used
-        for. Options are ``['train', 'validate', 'infer']``.
+    Note that this object is wrapped in a :class:`torch.utils.data.DataLoader`
+    before being passed to the :class:solaris.nets.train.Trainer` instance.
+
+    Attributes
+    ----------
+    df : :class:`pandas.DataFrame`
+        The :class:`pandas.DataFrame` specifying where inputs are stored.
+    aug : :class:`albumentations.core.composition.Compose`
+        An albumentations Compose object to pass imagery through before
+        passing it into the neural net. If an augmentation config subdict
+        was provided during initialization, this is created by parsing the
+        dict with :func:`solaris.nets.transform.process_aug_dict`.
+    batch_size : int
+        The batch size generated.
+    n_batches : int
+        The number of batches per epoch. Inferred based on the number of
+        input files in `df` and `batch_size`.
+    dtype : :class:`numpy.dtype`
+        The numpy dtype that image inputs should be when passed to the model.
+    is_categorical : bool
+        Indicates whether masks output are boolean or categorical labels.
+    dtype : class:`numpy.dtype`
+        The data type images should be converted to before being passed to
+        neural nets.
     """
 
-    def __init__(self, config, df, stage='train'):
+    def __init__(self, df, augs, batch_size, label_type='mask',
+                 is_categorical=False, dtype=None):
+        """
+        Create an instance of TorchDataset for use in model training.
+
+        Arguments
+        ---------
+        df : :class:`pandas.DataFrame`
+            A pandas DataFrame specifying images and label files to read into
+            the model. See `the reference file creation tutorial`_ for more.
+        augs : :class:`dict` or :class:`albumentations.core.composition.Compose`
+            Either the config subdict specifying augmentations to apply, or
+            a pre-created :class:`albumentations.core.composition.Compose`
+            object containing all of the augmentations to apply.
+        batch_size : int
+            The number of samples in a training batch.
+        label_type : str, optional
+            The type of labels to be used. At present, only ``"mask"`` is
+            supported.
+        is_categorical : bool, optional
+            Is the data categorical or boolean (default)?
+        dtype : str, optional
+            The dtype that image arrays should be converted to before being
+            passed to the neural net. If not provided, defaults to
+            ``"float32"``. Must be one of the `numpy dtype options`_.
+
+        .. _numpy dtype options: https://docs.scipy.org/doc/numpy/user/basics.types.html
+        """
         super().__init__()
+
         self.df = df
-        self.config = config
-        self.batch_size = self.config['batch_size']
+        self.batch_size = batch_size
         self.n_batches = int(np.floor(len(self.df)/self.batch_size))
+        self.aug = _check_augs(augs)
+        self.is_categorical = is_categorical
 
-        if config['data_specs']['dtype'] is None:
+        if dtype is None:
             self.dtype = np.float32  # default
-        else:
+        # if it's a string, get the appropriate object
+        elif isinstance(dtype, str):
             try:
-                self.dtype = getattr(np, config['data_specs']['dtype'])
+                self.dtype = getattr(np, dtype)
             except AttributeError:
-                raise ValueError('The data type {} is not supported'.format(
-                    config['data_specs']['dtype']))
-
-        if stage == 'train':
-            self.aug = process_aug_dict(self.config['training_augmentation'])
-        elif stage == 'validate':
-            self.aug = process_aug_dict(self.config['validation_augmentation'])
+                raise ValueError(
+                    'The data type {} is not supported'.format(dtype))
+        # lastly, check if it's already defined in the right format for use
+        elif issubclass(dtype, np.number) or isinstance(dtype, np.dtype):
+            self.dtype = dtype
 
     def __len__(self):
         return len(self.df)
 
     def __getitem__(self, idx):
-        'Get one image:mask pair'
+        """Get one image, mask pair"""
         # Generate indexes of the batch
         image = imread(self.df['image'].iloc[idx])
         mask = imread(self.df['label'].iloc[idx])
-        if not self.config['data_specs']['is_categorical']:
+        if not self.is_categorical:
             mask[mask != 0] = 1
         if len(mask.shape) == 2:
             mask = mask[:, :, np.newaxis]
@@ -210,11 +332,11 @@ class TorchDataset(Dataset):
         if self.aug:
             sample = self.aug(**sample)
         # add in additional inputs (if applicable)
-        additional_inputs = self.config['data_specs'].get('additional_inputs',
-                                                          None)
-        if additional_inputs is not None:
-            for input in additional_inputs:
-                sample[input] = self.df[input].iloc[idx]
+        # additional_inputs = self.config['data_specs'].get('additional_inputs',
+        #                                                   None)
+        # if additional_inputs is not None:
+        #     for input in additional_inputs:
+        #         sample[input] = self.df[input].iloc[idx]
 
         sample['image'] = _check_channel_order(sample['image'],
                                                'torch').astype(self.dtype)
@@ -227,15 +349,62 @@ class InferenceTiler(object):
     """An object to tile fragments of images for inference.
 
     This object allows you to pass images of arbitrary size into Solaris for
-    inference, similar to the pre-existing CosmiQ Works tool, BASISS_.
+    inference, similar to the pre-existing CosmiQ Works tool, BASISS_. The
+    object will step across an input image creating tiles of size
+    ``[height, width]``, taking steps of size ``[y_step, x_step]`` as it goes.
+    When it reaches an edge, it will take tiles from ``-height`` or ``-width``
+    to the edge. Clearly, these can overlap with one another; the intention
+    is that overlaps will be resolved using
+    :func:`solaris.raster.image.stitch_images` when re-creating the output.
 
     .. _BASISS: https://github.com/cosmiq/basiss
 
+    Attributes
+    ----------
+    framework : str
+        The deep learning framework used. Can be one of ``"torch"``,
+        ``"pytorch"``, or ``"keras"``.
+    width : int
+        The width of images to load into the neural net.
+    height : int
+        The height of images to load into the neural net.
+    x_step : int, optional
+        The step size taken in the x direction when sampling for new images.
+    y_step : int, optional
+        The step size taken in the y direction when sampling for new images.
+    aug : :class:`albumentations.core.composition.Compose`
+        Augmentations to apply before passing to a neural net. Generally used
+        for pre-processing.
+
+    See Also
+    --------
+    :func:`solaris.raster.image.stitch_images`
+    :func:`make_data_generator`
     """
 
     def __init__(self, framework, width, height, x_step=None, y_step=None,
                  augmentations=None):
-        """Create the tiler instance."""
+        """Create the tiler instance.
+
+        Arguments
+        ---------
+        framework : str
+            The deep learning framework used. Can be one of ``"torch"``,
+            ``"pytorch"``, or ``"keras"``.
+        width : int
+            The width of images to load into the neural net.
+        height : int
+            The height of images to load into the neural net.
+        x_step : int, optional
+            The step size taken in the x direction when sampling for new
+            images. If not provided, defaults to `width`.
+        y_step : int, optional
+            The step size taken in the y direction when sampling for new images.
+            If not provided, defaults to `height`.
+        aug : :class:`albumentations.core.composition.Compose`
+            Augmentations to apply before passing to a neural net. Generally used
+            for pre-processing.
+        """
         self.framework = framework
         self.width = width
         self.height = height
@@ -247,7 +416,7 @@ class InferenceTiler(object):
             self.y_step = self.height
         else:
             self.y_step = y_step
-        self.aug = augmentations
+        self.aug = _check_augs(augmentations)
 
     def __call__(self, im):
         """Create an inference array along with an indexing reference list.

--- a/solaris/nets/transform.py
+++ b/solaris/nets/transform.py
@@ -408,6 +408,14 @@ def build_pipeline(config):
     return train_aug_pipeline, val_aug_pipeline
 
 
+def _check_augs(augs):
+    """Check if augmentations are loaded in already or not."""
+    if isinstance(augs, dict):
+        return process_aug_dict(augs)
+    elif isinstance(augs, Compose):
+        return augs
+
+
 def process_aug_dict(pipeline_dict, meta_augs_list=['oneof', 'oneorother']):
     """Create a Compose object from an augmentation config dict.
 


### PR DESCRIPTION
Thank you for submitting your PR. Please read the template below, fill it out as appropriate, and make additional changes to your code as needed. Please feel free to submit your PR even if it doesn't satisfy all of the requirements below - simply prepend [WIP] to the PR title until it is ready for review by a maintainer. If you need assistance or review from a maintainer, add the label __Status: Help Needed__ or __Status: Review Needed__ respectively. After review, a maintainer will add the label __Status: Revision Needed__ if further work is required for the PR to be merged.

# Description

- improves documentation for the data generation objects in `sol.nets.datagen`
- re-factors `TorchDataset` and `KerasSegmentationSequence` so that they no longer take `config` as an argument, but instead take the individual pieces from that object as arguments. The idea here is to enable usage of these classes with the lower level API without users having to create the config object.

Fixes #247