### PR TITLE
ISS261: Instance mask creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ When a new version of `solaris` is released, all of the changes in the Unrelease
 ### Added
 20190930, nrweir: Added CHANGELOG.md (#259)
 20190930, nrweir: Add contributing guidelines, CONTRIBUTING.md (#260)
+20191003, nrweir: Added `solaris.vector.mask.instance_mask()` (#261)
 
 ### Removed
 

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -827,3 +827,108 @@ def _check_do_transform(df, reference_im, affine_obj):
     elif crs and (reference_im is not None or affine_obj is not None):
         # if the input has a CRS and another obj was provided for xforming
         return True
+
+
+def instance_mask(df, out_file=None, reference_im=None, geom_col='geometry',
+                  do_transform=None, affine_obj=None, shape=(900, 900),
+                  out_type='int', burn_value=255, burn_field=None):
+    """Convert a dataframe of geometries to a pixel mask.
+
+    Arguments
+    ---------
+    df : :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame`
+        A :class:`pandas.DataFrame` or :class:`geopandas.GeoDataFrame` instance
+        with a column containing geometries (identified by `geom_col`). If the
+        geometries in `df` are not in pixel coordinates, then `affine` or
+        `reference_im` must be passed to provide the transformation to convert.
+    out_file : str, optional
+        Path to an image file to save the output to. Must be compatible with
+        :class:`rasterio.DatasetReader`. If provided, a `reference_im` must be
+        provided (for metadata purposes).
+    reference_im : :class:`rasterio.DatasetReader` or `str`, optional
+        An image to extract necessary coordinate information from: the
+        affine transformation matrix, the image extent, etc. If provided,
+        `affine_obj` and `shape` are ignored.
+    geom_col : str, optional
+        The column containing geometries in `df`. Defaults to ``"geometry"``.
+    do_transform : bool, optional
+        Should the values in `df` be transformed from geospatial coordinates
+        to pixel coordinates? Defaults to ``None``, in which case the function
+        attempts to infer whether or not a transformation is required based on
+        the presence or absence of a CRS in `df`. If ``True``, either
+        `reference_im` or `affine_obj` must be provided as a source for the
+        the required affine transformation matrix.
+    affine_obj : `list` or :class:`affine.Affine`, optional
+        Affine transformation to use to convert from geo coordinates to pixel
+        space. Only provide this argument if `df` is a
+        :class:`geopandas.GeoDataFrame` with coordinates in a georeferenced
+        coordinate space. Ignored if `reference_im` is provided.
+    shape : tuple, optional
+        An ``(x_size, y_size)`` tuple defining the pixel extent of the output
+        mask. Ignored if `reference_im` is provided.
+    out_type : 'float' or 'int'
+    burn_value : `int` or `float`, optional
+        The value to use for labeling objects in the mask. Defaults to 255 (the
+        max value for ``uint8`` arrays). The mask array will be set to the same
+        dtype as `burn_value`. Ignored if `burn_field` is provided.
+    burn_field : str, optional
+        Name of a column in `df` that provides values for `burn_value` for each
+        independent object. If provided, `burn_value` is ignored.
+
+    Returns
+    -------
+    mask : :class:`numpy.array`
+        A pixel mask with 0s for non-object pixels and `burn_value` at object
+        pixels. `mask` dtype will coincide with `burn_value`.
+
+    """
+    # TODO: Refactor to remove some duplicated code here and in other mask fxns
+
+    if out_file and not reference_im:
+        raise ValueError(
+            'If saving output to file, `reference_im` must be provided.')
+    df = _check_df_load(df)
+
+    if len(df) == 0:
+        return np.zeros(shape=shape, dtype='uint8')
+
+    if do_transform is None:
+        # determine whether or not transform should be done
+        do_transform = _check_do_transform(df, reference_im, affine_obj)
+
+    df[geom_col] = df[geom_col].apply(_check_geom)  # load in geoms if wkt
+    if not do_transform:
+        affine_obj = Affine(1, 0, 0, 0, 1, 0)  # identity transform
+
+    if reference_im:
+        reference_im = _check_rasterio_im_load(reference_im)
+        shape = reference_im.shape
+        if do_transform:
+            affine_obj = reference_im.transform
+
+    # extract geometries and pair them with burn values
+    if burn_field:
+        if out_type == 'int':
+            feature_list = list(zip(df[geom_col],
+                                    df[burn_field].astype('uint8')))
+        else:
+            feature_list = list(zip(df[geom_col],
+                                    df[burn_field].astype('float')))
+    else:
+        feature_list = list(zip(df[geom_col], [burn_value]*len(df)))
+    # initialize the output array
+    output_arr = np.empty(shape=(shape[0], shape[1], len(feature_list)))
+    for idx, feat in enumerate(feature_list):
+        output_arr[:, :, idx] = features.rasterize([feat], out_shape=shape,
+                                                   transform=affine_obj)
+    if out_file:
+        meta = reference_im.meta.copy()
+        meta.update(count=1)
+        if out_type == 'int':
+            meta.update(dtype='uint8')
+        with rasterio.open(out_file, 'w', **meta) as dst:
+            for c in range(1, 1 + output_arr.shape[-1]):
+                dst.write(output_arr[:, :, c-1], indexes=c)
+            dst.close()
+
+    return output_arr

--- a/tests/test_vector/test_mask.py
+++ b/tests/test_vector/test_mask.py
@@ -5,7 +5,7 @@ import skimage
 from solaris.data import data_dir
 from solaris.vector.mask import footprint_mask, boundary_mask, \
     contact_mask, df_to_px_mask, mask_to_poly_geojson, road_mask, \
-    preds_to_binary
+    preds_to_binary, instance_mask
 
 
 class TestFootprintMask(object):
@@ -277,3 +277,25 @@ class TestRoadMask(object):
         assert np.array_equal(saved_output_mask, truth_mask)
         # clean up
         os.remove(os.path.join(data_dir, 'test_out.tif'))
+
+
+class TestInstanceMask(object):
+    """Tests for solaris.vector.mask.instance_mask."""
+
+    def test_make_mask_w_ref_image(self):
+        """Test creating a multichannel instance mask with geojson + ref im."""
+        output_mask = instance_mask(
+            os.path.join(data_dir, 'geotiff_labels.geojson'),
+            reference_im=os.path.join(data_dir, 'sample_geotiff.tif'),
+            do_transform=True,
+            out_file=os.path.join(data_dir, 'test_out.tif')
+            )
+        truth_mask = skimage.io.imread(os.path.join(data_dir,
+                                                    'sample_inst_mask.tif'))
+        saved_output_mask = skimage.io.imread(os.path.join(data_dir,
+                                                           'test_out.tif'))
+
+        assert np.array_equal(saved_output_mask, truth_mask)
+        # clean up
+        os.remove(os.path.join(data_dir, 'test_out.tif'))
+        assert np.array_equal(output_mask, truth_mask)


### PR DESCRIPTION
Adding `sol.vector.mask.instance_mask()` to create masks where each channel corresponds to an individual object instance.