### PR TITLE
Inferer calls use file in config file if no file/DataFrame specified

### DIFF
--- a/solaris/nets/infer.py
+++ b/solaris/nets/infer.py
@@ -46,7 +46,7 @@ class Inferer(object):
         if not os.path.isdir(self.output_dir):
             os.makedirs(self.output_dir)
 
-    def __call__(self, infer_df):
+    def __call__(self, infer_df=None):
         """Run inference.
 
         Arguments
@@ -54,9 +54,15 @@ class Inferer(object):
         infer_df : :class:`pandas.DataFrame` or `str`
             A :class:`pandas.DataFrame` with a column, ``'image'``, specifying
             paths to images for inference. Alternatively, `infer_df` can be a
-            path to a CSV file containing the same information.
+            path to a CSV file containing the same information.  Defaults to
+            ``None``, in which case the file path specified in the Inferer's
+            configuration dict is used.
 
         """
+
+        if infer_df is None:
+            infer_df = get_infer_df(self.config)
+
         inf_tiler = InferenceTiler(
             self.framework,
             width=self.config['data_specs']['width'],


### PR DESCRIPTION
# Description

If the user does not provide an argument to an Inferer call to specify a file or DataFrame, the Inferer will use the file path specified in its configuration dictionary by default.

Fixes # 282

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)



# How Has This Been Tested?

Please describe tests that you added to the pytest codebase (if applicable).

# Checklist:

- [ ] My PR has a descriptive title
- [ ] My code follows PEP8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
