### PR TITLE
Outputting empty GeoDataFrames to geojson in mask_to_poly_geojson()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ When a new version of `solaris` is released, all of the changes in the Unrelease
 ### Changed
 
 ### Fixed
+20191123, dphogan: Fixed issue in mask_to_poly_geojson() with empty GeoDataFrames.
 
 ### Deprecated
 

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -2,6 +2,7 @@ from ..utils.core import _check_df_load, _check_geom
 from ..utils.core import _check_skimage_im_load, _check_rasterio_im_load
 from ..utils.geo import gdf_get_projection_unit, reproject
 from ..utils.geo import geometries_internal_intersection
+from ..utils.tile import save_empty_geojson
 from .polygon import georegister_px_df, geojson_to_px_gdf, affine_transform_gdf
 import numpy as np
 from shapely.geometry import shape
@@ -798,7 +799,10 @@ def mask_to_poly_geojson(pred_arr, channel_scaling=None, reference_im=None,
     # save output files
     if output_path is not None:
         if output_type.lower() == 'geojson':
-            polygon_gdf.to_file(output_path, driver='GeoJSON')
+            if len(polygon_gdf) > 0:
+                polygon_gdf.to_file(output_path, driver='GeoJSON')
+            else:
+                save_empty_geojson(output_path, polygon_gdf.crs.to_epsg())
         elif output_type.lower() == 'csv':
             polygon_gdf.to_csv(output_path, index=False)
 


### PR DESCRIPTION
# Description

Fixes issue in mask_to_poly_geojson() with outputting empty GeoDataFrames to geojson.

Fixes #286

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)



# How Has This Been Tested?

Please describe tests that you added to the pytest codebase (if applicable).

# Checklist:

- [ ] My PR has a descriptive title
- [ ] My code follows PEP8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
