### PR TITLE
Filename argument for the raster tiler class's tile() method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ When a new version of `solaris` is released, all of the changes in the Unrelease
 20191122, dphogan: Inferer calls now take default DataFrame path from config dictionary (#282)
 20191125, nrweir: Added `solaris.utils.data.make_dataset_csv()` (#241)
 20191202, dphogan: Added fixed nodata value of 0 for mask files (#295)
+20191203: dphogan: Added filename argument to vector tiler's tile() (#297)
 
 ### Removed
 


### PR DESCRIPTION
# Description

This adds an optional argument (defaults to None) to RasterTiler class's tile() method, allowing the user to specify the string which begins the filenames of output files.  (If no string is specified, the RasterTiler uses the filename as usual.)

Fixes #297 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)



# How Has This Been Tested?

Please describe tests that you added to the pytest codebase (if applicable).

# Checklist:

- [ ] My PR has a descriptive title
- [ ] My code follows PEP8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
