### PR TITLE
Include empty mask files in footprint_mask() and contact_mask()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ When a new version of `solaris` is released, all of the changes in the Unrelease
 
 ### Fixed
 20191123, dphogan: Fixed issue in mask_to_poly_geojson() with empty GeoDataFrames.
+20191204, dphogan: Fixed issue with file output from footprint_mask() and contact_mask() (#301)
 
 ### Deprecated
 


### PR DESCRIPTION
# Description

footprint_mask() and contact_mask() currently end early and return an array of zeros if they are given an empty DataFrame as input.  However, that means they won't create any file if file output is enabled and the input DataFrame happens to not have any building footprints.  This pull causes the functions to end early only if no file output is requested, and also adds some if-statements further down in the functions so they won't crash if run on empty DataFrames.

Fixes #301 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)



# How Has This Been Tested?

Please describe tests that you added to the pytest codebase (if applicable).

# Checklist:

- [ ] My PR has a descriptive title
- [ ] My code follows PEP8
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
