### PR TITLE
[WIP] Bug fixes, geojson2coco improvements, restrict_by_aoi, and nodata filling

### DIFF
--- a/solaris/data/coco.py
+++ b/solaris/data/coco.py
@@ -110,8 +110,8 @@ def geojson2coco(image_src, label_src, output_path=None, image_ext='.tif',
         to ``True`` will induce solaris to descend into subdirectories to find
         files. By default, solaris does not traverse the directory tree.
     remove_all_multipolygons : bool, optional
-        Filters multipolygons out of each tile geodataframe. Alternatively you 
-        can edit each polygon manually to be a polygon.
+        Filters MultiPolygons and GeometryCollections out of each tile geodataframe. Alternatively you 
+        can edit each polygon manually to be a polygon before converting to COCO format.
     verbose : int, optional
         Verbose text output. By default, none is provided; if ``True`` or
         ``1``, information-level outputs are provided; if ``2``, extremely
@@ -413,6 +413,7 @@ def df_to_coco_annos(df, output_path=None, geom_col='geometry',
     def _row_to_coco(row, geom_col, category_id_col, image_id_col, score_col):
         "get a single annotation record from a row of temp_df."
         if score_col is None:
+            
             return {'id': row['annotation_id'],
                     'image_id': int(row[image_id_col]),
                     'category_id': int(row[category_id_col]),

--- a/solaris/data/coco.py
+++ b/solaris/data/coco.py
@@ -15,7 +15,8 @@ import logging
 def geojson2coco(image_src, label_src, output_path=None, image_ext='.tif',
                  matching_re=None, category_attribute=None, score_attribute=None,
                  preset_categories=None, include_other=True, info_dict=None,
-                 license_dict=None, recursive=False, remove_all_multipolygons=False, verbose=0):
+                 license_dict=None, recursive=False, remove_all_multipolygons=False, 
+                 override_crs=False, verbose=0):
     """Generate COCO-formatted labels from one or multiple geojsons and images.
 
     This function ingests optionally georegistered polygon labels in geojson
@@ -215,7 +216,8 @@ def geojson2coco(image_src, label_src, output_path=None, image_ext='.tif',
                 curr_gdf = geojson_to_px_gdf(
                     curr_gdf,
                     im_path=match_df.loc[match_df['label_fname'] == gj,
-                                         'image_fname'].values[0])
+                                         'image_fname'].values[0],
+                    override_crs=override_crs)
                 curr_gdf['image_id'] = image_ref[match_df.loc[
                     match_df['label_fname'] == gj, 'image_fname'].values[0]]
         # handle case with multiple images, one big geojson
@@ -228,7 +230,8 @@ def geojson2coco(image_src, label_src, output_path=None, image_ext='.tif',
             logger.debug('Converting to pixel coordinates.')
             # match the two images
             curr_gdf = geojson_to_px_gdf(curr_gdf,
-                                         im_path=list(image_ref.keys())[0])
+                                         im_path=list(image_ref.keys())[0], 
+                                         override_crs=override_crs)
             curr_gdf['image_id'] = list(image_ref.values())[0]
         curr_gdf = curr_gdf.rename(
             columns={tmp_category_attribute: 'category_str'})

--- a/solaris/tile/raster_tile.py
+++ b/solaris/tile/raster_tile.py
@@ -494,7 +494,7 @@ class RasterTiler(object):
                     # base-1 vs. base-0 indexing...bleh
                     tile_src.write(tile_data[band-1, :, :], band)
             tile_src.close()
-            return fill_values
+        return fill_values
 
     def _create_cog(self, src_path, dest_path):
         """Overwrite non-cloud-optimized GeoTIFF with a COG."""

--- a/solaris/tile/raster_tile.py
+++ b/solaris/tile/raster_tile.py
@@ -151,7 +151,16 @@ class RasterTiler(object):
     def tile(self, src, dest_dir=None, channel_idxs=None, nodata=None,
              alpha=None, restrict_to_aoi=False,
              dest_fname_base=None, nodata_threshold = None):
+        """An object to tile geospatial image strips into smaller pieces.
 
+        Arguments
+        ---------
+        src : :class:`rasterio.io.DatasetReader` or str
+            The source dataset to tile.
+        nodata_threshold : float, optional
+            Nodata percentages greater than this threshold will not be saved as tiles.
+        """
+        
         tile_gen = self.tile_generator(src, dest_dir, channel_idxs, nodata,
                                        alpha, self.aoi_boundary, restrict_to_aoi)
 
@@ -165,7 +174,7 @@ class RasterTiler(object):
             new_tile_bounds = []
             for tile_data, mask, profile, tb in tqdm(tile_gen):
                 nodata_perc = (tile_data == profile['nodata']).sum() / (tile_data.shape[0] * tile_data.shape[1])
-                if nodata_perc > nodata_threshold:
+                if nodata_perc < nodata_threshold:
                     dest_path = self.save_tile(
                         tile_data, mask, profile, dest_fname_base)
                     self.tile_paths.append(dest_path)

--- a/solaris/tile/raster_tile.py
+++ b/solaris/tile/raster_tile.py
@@ -172,7 +172,7 @@ class RasterTiler(object):
                 raise ValueError("aoi_boundary must be specified when RasterTiler is called.")
             mask_geometry = self.aoi_boundary.intersection(box(*src.bounds)) # prevents enlarging raster to size of aoi_boundary
             index_lst = list(np.arange(1,src.meta['count']+1))
-            # no need to use transform t since we don't crop
+            # no need to use transform t since we don't crop. cropping messes up transform of tiled outputs
             arr, t = rasterio_mask(src, [mask_geometry], all_touched=False, invert=False, nodata=src.meta['nodata'], 
                          filled=True, crop=False, pad=False, pad_width=0.5, indexes=list(index_lst))
             with rasterio.open(restricted_im_path, 'w', **src.profile) as dest:

--- a/solaris/tile/raster_tile.py
+++ b/solaris/tile/raster_tile.py
@@ -466,6 +466,9 @@ class RasterTiler(object):
             Default is to not fill any nodata values. Otherwise, pixels outside of the aoi_boundary and pixels inside 
             the aoi_boundary with the nodata value will be filled. "mean" will fill pixels with the channel-wise mean. 
             Providing an int or float will fill pixels in all channels with the provided value.
+            
+        Returns: list
+            The fill values, in case the mean of the src image should be used for normalization later.
         """
         src = _check_rasterio_im_load(self.src_name)
         if nodata_fill == "mean":
@@ -491,6 +494,7 @@ class RasterTiler(object):
                     # base-1 vs. base-0 indexing...bleh
                     tile_src.write(tile_data[band-1, :, :], band)
             tile_src.close()
+            return fill_values
 
     def _create_cog(self, src_path, dest_path):
         """Overwrite non-cloud-optimized GeoTIFF with a COG."""

--- a/solaris/tile/vector_tile.py
+++ b/solaris/tile/vector_tile.py
@@ -209,7 +209,7 @@ def search_gdf_polygon(gdf, tile_polygon):
         :py:class:`geopandas.GeoDataFrame`.
 
     """
-
+    crs = gdf.crs
     sindex = gdf.sindex
     possible_matches_index = list(sindex.intersection(tile_polygon.bounds))
     possible_matches = gdf.iloc[possible_matches_index]
@@ -218,6 +218,7 @@ def search_gdf_polygon(gdf, tile_polygon):
         ]
     if precise_matches.empty:
         precise_matches = gpd.GeoDataFrame(geometry=[])
+    precise_matches.crs = crs # precise_matches crs is lost so we need to reassign it
     return precise_matches
 
 
@@ -296,7 +297,7 @@ def clip_gdf(gdf, tile_bounds, min_partial_perc=0.0, geom_type="Polygon",
             gdf['origlen'] = 0
     # TODO must implement different case for lines and for spatialIndex
     # (Assume RTree is already performed)
-
+    
     cut_gdf = gdf.copy()
     cut_gdf.geometry = gdf.intersection(tb)
 

--- a/solaris/tile/vector_tile.py
+++ b/solaris/tile/vector_tile.py
@@ -218,7 +218,6 @@ def search_gdf_polygon(gdf, tile_polygon):
         ]
     if precise_matches.empty:
         precise_matches = gpd.GeoDataFrame(geometry=[])
-    precise_matches.crs = crs # precise_matches crs is lost so we need to reassign it
     return precise_matches
 
 

--- a/solaris/utils/geo.py
+++ b/solaris/utils/geo.py
@@ -740,6 +740,8 @@ def polygon_to_coco(polygon):
         coords = polygon.exterior.coords.xy
     elif isinstance(polygon, str):  # assume it's WKT
         coords = loads(polygon).exterior.coords.xy
+    elif isinstance(polygon, MultiPolygon):
+        raise ValueError("You have MultiPolygon types in your label df. Remove or fix these to be Polygon geometry types.")
     else:
         raise ValueError('polygon must be a shapely geometry or WKT.')
     # zip together x,y pairs
@@ -813,8 +815,14 @@ def split_geom(geometry, tile_size, resolution=None, use_projection_units=False,
                          tile_size[1]*resolution[1]]
     else:
         tmp_tile_size = tile_size
-
-    bounds = geometry.bounds
+        
+    if src_img is not None:
+        src_img = _check_rasterio_im_load(src_img)
+        geometry = geometry.intersection(box(*src_img.bounds))
+        bounds = geometry.bounds
+    else:
+        bounds = geometry.bounds
+        
     xmin = bounds[0]
     xmax = bounds[2]
     ymin = bounds[1]

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -948,7 +948,7 @@ def instance_mask(df, out_file=None, reference_im=None, geom_col='geometry',
     if reference_im:
         reference_im = _check_rasterio_im_load(reference_im)
     try:
-            bad_data_mask = (reference_im.read() == reference_im.nodata).any(axis=0) # take logical and along all dims so that all pixxels not -9999 across bands
+        bad_data_mask = (reference_im.read() == reference_im.nodata).any(axis=0) # take logical and along all dims so that all pixxels not -9999 across bands
     except AttributeError as ae:  # raise another, more verbose AttributeError
         raise AttributeError("A nodata value is not defined for the source image. Make sure the reference_im has a nodata value defined.") from ae
         bad_data_mask = np.dstack([bad_data_mask]*output_arr.shape[2])

--- a/solaris/vector/mask.py
+++ b/solaris/vector/mask.py
@@ -905,6 +905,8 @@ def instance_mask(df, out_file=None, reference_im=None, geom_col='geometry',
     df = _check_df_load(df)
 
     if len(df) == 0:
+        reference_im = _check_rasterio_im_load(reference_im)
+        shape = reference_im.shape
         return np.zeros(shape=shape, dtype='uint8')
 
     if do_transform is None:

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -193,7 +193,7 @@ def georegister_px_df(df, im_path=None, affine_obj=None, crs=None,
 
 
 def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
-                      output_path=None):
+                      output_path=None, override_crs=False):
     """Convert a geojson or set of geojsons from geo coords to px coords.
 
     Arguments
@@ -216,7 +216,11 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
     output_path : str, optional
         Path to save the resulting output to. If not provided, the object
         won't be saved to disk.
-
+    override_geojson_crs: bool, optional
+        If the geojsons gtenerated by the vector tiler or otherwise were saved
+        out with a non EPSG code projection, an EPSG code is chosen and for 
+        the metadata and this can be wrong. True sets the gdf crs to that of the 
+        image, they should have the same underlying projection for this to work.
     Returns
     -------
     output_df : :class:`pandas.DataFrame`
@@ -234,6 +238,9 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
     gdf = _check_gdf_load(geojson)
 
     if len(gdf):  # if there's at least one geometry
+        # The vector tiler saves out geojsons with wkt crs as epsg which can be wrong
+        if override_crs:
+            gdf.crs = im.crs 
         overlap_gdf = get_overlapping_subset(gdf, im)
     else:
         overlap_gdf = gdf

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -414,11 +414,13 @@ def gdf_to_yolo(geodataframe, image, output_dir, column='single_id',
 
 def remove_multipolygons(gdf):
     """
-    Filters out rows of a geodataframe containing multipolygons.
+    Filters out rows of a geodataframe containing MultiPolygons and GeometryCollections.
  
-    This function is optionally used in geojson2coco.
+    This function is optionally used in geojson2coco. For instance segmentation, where 
+    objects are composed of single polygons, multi part geometries need to be either removed or
+    inspected manually to be resolved as a single geometry.
     """
-    mask = (gdf.geom_type == "MultiPolygon")
+    mask = (gdf.geom_type == "MultiPolygon") | (gdf.geom_type == "GeometryCollection")
     if mask.any():
         return gdf.drop(gdf[mask].index).reset_index(drop=True)
     else:

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -404,3 +404,16 @@ def gdf_to_yolo(geodataframe, image, output_dir, column='single_id',
             shutil.move(image, remove_no_labels_dir)
 
     return gdf
+
+def remove_multipolygons(gdf):
+    """
+    Filters out rows of a geodataframe containing multipolygons.
+ 
+    This function is optionally used in geojson2coco.
+    """
+    mask = (gdf.geom_type == "MultiPolygon")
+    if mask.any():
+        return gdf.drop(gdf[mask].index).reset_index(drop=True)
+    else:
+        return gdf
+

--- a/solaris/vector/polygon.py
+++ b/solaris/vector/polygon.py
@@ -216,7 +216,7 @@ def geojson_to_px_gdf(geojson, im_path, geom_col='geometry', precision=None,
     output_path : str, optional
         Path to save the resulting output to. If not provided, the object
         won't be saved to disk.
-    override_geojson_crs: bool, optional
+    override_crs: bool, optional
         If the geojsons gtenerated by the vector tiler or otherwise were saved
         out with a non EPSG code projection, an EPSG code is chosen and for 
         the metadata and this can be wrong. True sets the gdf crs to that of the 


### PR DESCRIPTION
# Description
This PR addresses the following issues: 

https://github.com/CosmiQ/solaris/issues/327 by allowing an option to set areas outside an aoi_boundary to the src image's nodata value when tiling.

https://github.com/CosmiQ/solaris/issues/328 by adding a method to the `RasterTiler` class that fills tiles with the mean of the src image. If this is run after restrict_by_aoi, all nodata values outside of the aoi are filled, along with other nodata values in the image.

`geojson2coco` would fail if the geodataframe input had any MultiPolygon or GeometryCollection types. I added an optional argument to ignore these when converting the geodataframe to COCO format

There was a bug in the raster_tiler's use of the split_geom function, where the aoi boundary was not intersected with the src_image boundary prior to tiling, causing many nodata areas outside the src_img boundary to be tiled.

and finally, apologies for missing https://github.com/CosmiQ/solaris/issues/317 but I think issues remain for how CRSs are handled. I wasn't able to save a geopandas geodataframe with a CRS that didn't have an EPSG code, which caused it to default to 4326. I added an optional argument to override the CRS in the geojson_to_px function with the CRS of the src image.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)

# How Has This Been Tested?

All original tests pass, but I should write some new tests, especially to cover the additions to the raster_tiler.

# Checklist:

- [x] My PR has a descriptive title
- [ ] My code follows PEP8
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [ ] My PR does not reduce coverage in Codecov

_If your PR does not fulfill all of the requirements in the checklist above, that's OK!_ Just prepend [WIP] to the PR title until they are all satisfied. If you need help, @-mention a maintainer and/or add the __Status: Help Needed__ label.
