### PR TITLE
Fix missing comma in setup.py that breaks conda environment export __Status: Review Needed__ 

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ else:
                  'affine>=2.3.0',
                  'albumentations==0.4.3',
                  'fiona>=1.7.13',
-                 'gdal>=3.0.2'
+                 'gdal>=3.0.2',
                  'geopandas>=0.7.0',
                  'matplotlib>=3.1.2',
                  'networkx>=2.4',


### PR DESCRIPTION
# Description

I was getting a conda env export error when exporting a complex but correctly built environment:

```
# rave at rave-desktop in ~/CropMask_RCNN/app on git:pytorchapi ✖︎ [0:18:31]
→ conda env export > app-environment-exp.yml                                                        

InvalidVersionSpec: Invalid version '3.0.2geopandas>=0.7.0': invalid character(s)

```

[This comment](https://github.com/conda/conda/issues/9624#issuecomment-737107961) showed me that the issue could be in the setup.py of a dependency and it turned out to be right.

I found the issue was in solaris by searching for the string `3.0.2geopandas>=0.7.0`

```
grep -r "3.0.2geopandas>=0.7.0" ~/miniconda3/envs/cropmask/lib/python3.7/site-packages/ 
```

Fixes # (issue)

Add a comma in setup.py

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

I'm not sure who is the current maintainer so I'll at @dphogan, but a review and merge from anyone will do! Thanks in advance for reviewing.