### PR TITLE
[WIP] Move all CI/CD to Github Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,5 +43,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install tox tox-gh-actions
+      - name: Lint with tox
+        run: tox -e lint
+      # - name: Format with tox
+      #   run: tox -e format
+      - name: Flake8 with tox
+        run: tox -e flake8
       - name: Test with tox
         run: tox

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Flake8 with tox
         run: tox -e flake8
       - name: Test with tox
-        run: tox
+        run: tox -e test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
         gdal-version: ["3.4.0", "3.3.3"]
         include:
           - python-version: "3.8"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     name: Docker | GDAL=${{ matrix.gdal-version }} | python=${{ matrix.python-version }}
-    container: osgeo/gdal:ubuntu-full-${{ matrix.gdal-version }}
+    container: osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
     strategy:
       fail-fast: false
       matrix:
@@ -42,7 +42,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install tox tox-gh-actions
+          python -m pip install tox
       - name: Lint with tox
         run: tox -e lint
       # - name: Format with tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,44 +1,42 @@
 [tox]
-envlist = py37,py38,py39,py310
+envlist = 
+    lint, 
+    format, 
+    flake8,
+    test
 
-[gh-actions]
-python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
-    3.10: py310
-
-[testenv]
+[testenv:test]
 extras = test
-commands=
+commands =
     python -m pytest --cov --cov-report xml --cov-report term-missing --ignore=venv
 
-# Lint
-[flake8]
-exclude = .git,__pycache__,docs/source/conf.py,old,build,dist
-max-line-length = 90
-
-[mypy]
-no_strict_optional = True
-ignore_missing_imports = True
-
-[tool:isort]
-include_trailing_comma = True
-multi_line_output = 3
-line_length = 90
-known_first_party = solaris
-default_section = THIRDPARTY
-
-# Autoformatter
-[testenv:black]
-basepython = python3
+[testenv:lint]
+basepython = python3.9
 skip_install = true
-deps =
+deps = 
+    isort
     black
 commands =
-    black
+    - isort --check-only --df .
+    - black --check --diff --color .
 
-# Release tooling
+[testenv:flake8]
+basepython = python3.9
+skip_install = true
+deps = flake8
+commands = 
+    - flake8
+
+[testenv:format]
+basepython = python3.9
+skip_install = true
+deps = 
+    isort
+    black
+commands =
+    - isort .
+    - black .
+
 [testenv:build]
 basepython = python3
 skip_install = true
@@ -60,3 +58,25 @@ deps =
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing dist/*
+
+[flake8]
+extend-ignore = 
+    E203,
+exclude =
+    .git,
+    __pycache__,
+    docs/source/conf.py,
+    old,
+    build,
+    dist,
+    .tox
+max-line-length = 88
+max-complexity = 10
+
+[isort]
+profile = black
+
+[black]
+line-length = 88
+target-version = ['py37', 'py38', 'py39', 'py310']
+experimental_string_processing = true

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ envlist =
 [testenv:test]
 extras = test
 commands =
-    python -m pytest --cov --cov-report xml --cov-report term-missing --ignore=venv
+    - python -m pytest --cov --cov-report xml --cov-report term-missing --ignore=venv
 
 [testenv:lint]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ commands =
     python -m pytest --cov --cov-report xml --cov-report term-missing --ignore=venv
 
 [testenv:lint]
-basepython = python3.9
+basepython = python3
 skip_install = true
 deps = 
     isort
@@ -21,14 +21,14 @@ commands =
     - black --check --diff --color .
 
 [testenv:flake8]
-basepython = python3.9
+basepython = python3
 skip_install = true
 deps = flake8
 commands = 
     - flake8
 
 [testenv:format]
-basepython = python3.9
+basepython = python3
 skip_install = true
 deps = 
     isort


### PR DESCRIPTION
This PR adds support to lint, format & test the codebase across different python & gdal versions.


# Description

We can run different steps as:
`tox -e [lint/test/format/flake8]`

We are not relying on `tox.ini` file for running different python environments. That is taken care of using github runners. I commented out the format step as that would modify the codebase.

Fixes #440 [WIP]

## Type of change

- [ ] New feature (non-breaking change which adds functionality)
- [ ] __Breaking change__ (fix or feature that would cause existing functionality to not work as expected - these changes will not be merged until major releases!)

# How Has This Been Tested?

There is technically no change in the codebase, so I have not added any new testcases.

# Checklist:

- [x] My PR has a descriptive title
- [ ] My code follows PEP8
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new errors
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] My PR passes Travis CI tests
- [x] My PR does not reduce coverage in Codecov

cc @rbavery @vincentsarago